### PR TITLE
[AT-1459] Show original error and stack trace in logs for handleRetryableExcept…

### DIFF
--- a/integrations/flink_connector/flink-connector-timestream/src/main/java/com/amazonaws/samples/connectors/timestream/DefaultWriteRequestFailureHandler.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/main/java/com/amazonaws/samples/connectors/timestream/DefaultWriteRequestFailureHandler.java
@@ -110,11 +110,11 @@ public class DefaultWriteRequestFailureHandler implements WriteRequestFailureHan
             // if it's AwsServiceException, log it along StatusCode and RequestId
             AwsServiceException se = (AwsServiceException) e;
             // no reason to log stack trace - there won't be anything what can help
-            LOG.error("Retryable '{}' occurred while inserting to Timestream. Records insertion will be retried. " +
-                    "Details: Status Code: {}, Request ID: {}", e.getClass().getSimpleName(), se.statusCode(), se.requestId());
+            LOG.error(String.format("Retryable '%s' occurred while inserting to Timestream. Records insertion will be retried. " +
+                    "Details: Status Code: %s, Request ID: %s", e.getClass().getSimpleName(), se.statusCode(), se.requestId()), e);
         } else {
-            LOG.error("Retryable '{}' occurred while inserting to Timestream. Records insertion will be retried.",
-                    e.getClass().getSimpleName());
+            LOG.error(String.format("Retryable '%s' occurred while inserting to Timestream. Records insertion will be retried.",
+                    e.getClass().getSimpleName()), e);
         }
         retryOrSuccessCompletionConsumer.accept(records); // retry all records
     }


### PR DESCRIPTION
## Summary
Could provide errorMessage of ***AwsServiceException*** When ***handleRetryableException***

## Description
Problem relates to the retry functionality that error logs do not show original stack trace.

During the fix the original error has been added to the log after the text message.
***log.error("ExisitngMessage", OriginalThrowableException)***

## Related Issue
[awslabs#128](https://github.com/awslabs/amazon-timestream-tools/issues/128)

## Tests performed / created
### Unit tests: 
Run and validate ***DefaultWriteRequestFailureHandlerTest***

### Manual verification:

- Modify ***timestream-connector*** to ***throw new RuntimeException("TEST")***
- Build the connector: ***mvn clean package***
- Include connector to sample application
- Run sample application:  ***mvn install exec:java -Dexec.mainClass="com.amazonaws.samples.kinesis2timestream.StreamingJob" -Dexec.args="--InputStreamName TimestreamTestStream --Region us-east-1 --TimestreamDbName kdaflink --TimestreamTableName kinesisdata" -Dexec.classpathScope=test***

#### Current results:
The following logs has been written:
***Retryable 'InternalServerException' occurred while inserting to Timestream. Records insertion will be retried. Details: Status Code: 0, Request ID: null***

#### After change results:
***Retryable 'InternalServerException' occurred while inserting to Timestream. Records insertion will be retried. Details: Status Code: 0, Request ID: null
java.lang.RuntimeException: TEST
  at com.amazonaws.samples.connectors.timestream.handleValidationException(DefaultWriteRequestFailureHandler.java:113)
...***

## Additional Reviewers
@alexeytemnikov