### PR TITLE
[AT-1460] Change the function for parsing string to bool

### DIFF
--- a/integrations/sagemaker/timestreamquery.py
+++ b/integrations/sagemaker/timestreamquery.py
@@ -56,11 +56,14 @@ def parseScalar(c_type, data):
     elif (c_type == "INTEGER"):
         return int(data)
     elif (c_type == "BOOLEAN"):
-        return bool(data)
+        return toBool(data)
     elif (c_type == "TIMESTAMP"):
         return data
     else:
         return data
+
+def toBool(data):
+    return str(data).lower() in ('y', 'yes', 't', 'true', 'on', '1')
 
 def parseArrayData(c_type, data):
     if data == None:

--- a/integrations/sagemaker/timestreamquery_test.py
+++ b/integrations/sagemaker/timestreamquery_test.py
@@ -1,0 +1,26 @@
+import unittest
+import timestreamquery
+
+class TestStreamQuery(unittest.TestCase):
+
+    def test_bool_true(self):
+        self.assertTrue(timestreamquery.toBool('True'))
+        self.assertTrue(timestreamquery.toBool('yes'))
+        self.assertTrue(timestreamquery.toBool('t'))
+        self.assertTrue(timestreamquery.toBool('true'))
+        self.assertTrue(timestreamquery.toBool('on'))
+        self.assertTrue(timestreamquery.toBool('1'))
+        self.assertTrue(timestreamquery.toBool(1))
+        self.assertTrue(timestreamquery.toBool(True))
+
+    def test_bool_false(self):
+        self.assertFalse(timestreamquery.toBool('Tr'))
+        self.assertFalse(timestreamquery.toBool('f'))
+        self.assertFalse(timestreamquery.toBool('0'))
+        self.assertFalse(timestreamquery.toBool(0))
+        self.assertFalse(timestreamquery.toBool('False'))
+        self.assertFalse(timestreamquery.toBool(False))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
bool('false') also returns True

## Description
The original function that parse string to Bool always return True value even if we specify ***("False")***
There is a way from python core that can convert the value : ***bool(distutils.util.strtobool(some_string))***
But from ***Python >=3.12*** that code not part of standart library.
So the solution has been implemented as internal function

## Related Issue
[awslabs#134](https://github.com/awslabs/amazon-timestream-tools/issues/134)

## Tests performed / created
UnitTest: ***timestreamquery_test.py*** that cover multiple parse conditions has been added

The created function tested manually with the following test cases:
Multiple inputs has been provided to verify boolean results:
***True/False/1/0/"True"/"False"/"true"/"false",'y', 'yes', 't', 'true', 'on', '1'***

### Before change result was:
Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue/Thue (always true)

### After the fix:
Thue/False/Thue/False/Thue/False/Thue/False/Thue/Thue/Thue/Thue/Thue/Thue (all results correct)

## Additional Reviewers
@alexeytemnikov