### PR TITLE
[AT-1461] Change the default ignore condition for serializer

### DIFF
--- a/sample_apps/dotnet/QueryExample.cs
+++ b/sample_apps/dotnet/QueryExample.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Amazon.TimestreamQuery;
 using Amazon.TimestreamQuery.Model;

--- a/sample_apps/dotnet/QueryExample.cs
+++ b/sample_apps/dotnet/QueryExample.cs
@@ -278,7 +278,7 @@ namespace TimestreamDotNetSample
             List<ColumnInfo> columnInfo = response.ColumnInfo;
             var options = new JsonSerializerOptions
             {
-                IgnoreNullValues = true
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
             List<String> columnInfoStrings = columnInfo.ConvertAll(x => JsonSerializer.Serialize(x, options));
             List<Row> rows = response.Rows;

--- a/sample_apps/dotnet/QueryExample.cs
+++ b/sample_apps/dotnet/QueryExample.cs
@@ -280,6 +280,7 @@ namespace TimestreamDotNetSample
             var options = new JsonSerializerOptions
             {
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                //To ignore all null-value properties, see all possible JsonIgnoreCondition values from .net original documentation
             };
             List<String> columnInfoStrings = columnInfo.ConvertAll(x => JsonSerializer.Serialize(x, options));
             List<Row> rows = response.Rows;

--- a/sample_apps/dotnet/UnloadUtil.cs
+++ b/sample_apps/dotnet/UnloadUtil.cs
@@ -95,7 +95,7 @@ using Amazon.TimestreamQuery;
              List<ColumnInfo> columnInfo = response.ColumnInfo;
              var options = new JsonSerializerOptions
              {
-                 IgnoreNullValues = true
+                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
              };
              List<String> columnInfoStrings = columnInfo.ConvertAll(x => JsonSerializer.Serialize(x, options));
              List<Row> rows = response.Rows;

--- a/sample_apps/dotnet/UnloadUtil.cs
+++ b/sample_apps/dotnet/UnloadUtil.cs
@@ -97,6 +97,7 @@ using Amazon.TimestreamQuery;
              var options = new JsonSerializerOptions
              {
                  DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                 //To ignore all null-value properties, see all possible JsonIgnoreCondition values from .net original documentation
              };
              List<String> columnInfoStrings = columnInfo.ConvertAll(x => JsonSerializer.Serialize(x, options));
              List<Row> rows = response.Rows;

--- a/sample_apps/dotnet/UnloadUtil.cs
+++ b/sample_apps/dotnet/UnloadUtil.cs
@@ -6,6 +6,7 @@ using Amazon.TimestreamQuery;
  using System.IO;
  using System.Collections.Generic;
  using System.Text.Json;
+ using System.Text.Json.Serialization;
  using System.Linq;
  using Newtonsoft.Json.Linq;
 


### PR DESCRIPTION
## Summary
dotnet/UnloadUtil.cs(98,18) warning ***SYSLIB0020: 'JsonSerializerOptions.IgnoreNullValues'*** is obsolete

## Description
Currently, during building .NET sample application warning messages are produced in the log files. This PR addresses this issue by changing default json configuration that uses in the latest versions of .Net

The following configuration was added to support ignore values.
***{
DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
};***

## Related Issue
[awslabs#140](https://github.com/awslabs/amazon-timestream-tools/issues/140)

## Tests performed / created
Following Tests has been executed manually:
***.net Version - <3.0>***

- Navigate to folder for .NET sample app ***"sample_apps/dotnet"***
- Add all required dependency from ***README.md***
- Run the project with sample csv: ***dotnet run -- -f ../data/sample.csv***
- Check logs

#### Before Fix: 
The following errors shown in logs:
***/workspaces/amazon-timestream-tools/sample_apps/dotnet/UnloadUtil.cs(98,18): warning SYSLIB0020: 'JsonSerializerOptions.IgnoreNullValues' is obsolete: 'JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.' [/workspaces/amazon-timestream-tools/sample_apps/dotnet/TimestreamDotNetSample.csproj]
/workspaces/amazon-timestream-tools/sample_apps/dotnet/QueryExample.cs(281,17): warning SYSLIB0020: 'JsonSerializerOptions.IgnoreNullValues' is obsolete: 'JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.' [/workspaces/amazon-timestream-tools/sample_apps/dotnet/TimestreamDotNetSample.csproj]***

#### After Fix: 
No error messages in logs
***JSON writer do not write null values***

## Additional Reviewers
@alexeytemnikov

[AT-1461]: https://bitquill.atlassian.net/browse/AT-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ