### PR TITLE
Clarify host formatting for Influx migration script

### DIFF
--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -134,7 +134,7 @@ The following is a formatted version of the output:
 
 **`--src-bucket SRC_BUCKET`**: Optional. The name of the InfluxDB bucket in the source server. If not provided, then `--full` must be provided.
 
-**`--src-host SRC_HOST`**: Optional. The host for the source server. Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or https://some-domain:8086. Defaults to http://localhost:8086.
+**`--src-host SRC_HOST`**: Optional. The host for the source server. Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or https://<domain>:<port>. Defaults to http://localhost:8086b if no value is specified.
 
 > As mentioned previously, `mountpoint-s3` and `rclone` are needed if `--s3-bucket` is to be used, but can be ignored if the user doesn't provide a value for `--s3-bucket`, in which case backup files will be stored in a unique directory locally.
 

--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -114,7 +114,7 @@ The following is a formatted version of the output:
 
 **`--dest-bucket DEST_BUCKET`**: Optional. The name of the InfluxDB bucket in the destination server, must not be an already existing bucket. Defaults to value of `--src-bucket` or `None` if `--src-bucket` not provided.
 
-**`--dest-host DEST_HOST`**: The host for the destination server. Example: http://localhost:8086.
+**`--dest-host DEST_HOST`**: The host for the destination server. Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or https://some-domain:8086.
 
 **`--dest-org DEST_ORG`**: Optional. The name of the organization to restore buckets to in the destination server. If this is omitted, then all migrated buckets from the source server will retain their original organization and migrated buckets may not be visible in the destination server without creating and switching organizations. This value will be used in all forms of restoration whether a single bucket, a full migration, or any migration using csv files for backup and restoration.
 
@@ -134,7 +134,7 @@ The following is a formatted version of the output:
 
 **`--src-bucket SRC_BUCKET`**: Optional. The name of the InfluxDB bucket in the source server. If not provided, then `--full` must be provided.
 
-**`--src-host SRC_HOST`**: Optional. The host for the source server. Defaults to http://localhost:8086.
+**`--src-host SRC_HOST`**: Optional. The host for the source server. Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or https://some-domain:8086. Defaults to http://localhost:8086.
 
 > As mentioned previously, `mountpoint-s3` and `rclone` are needed if `--s3-bucket` is to be used, but can be ignored if the user doesn't provide a value for `--s3-bucket`, in which case backup files will be stored in a unique directory locally.
 

--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -178,7 +178,7 @@ After meeting the prerequisites:
 
     - (optional) S3 bucket name and credentials, AWS CLI credentials should be set in the OS environment variables.
       ```
-      # AWS credentials (for timestream testing)
+      # AWS credentials
       export AWS_ACCESS_KEY_ID="xxx"
       export AWS_SECRET_ACCESS_KEY="xxx"
       ```

--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -114,7 +114,7 @@ The following is a formatted version of the output:
 
 **`--dest-bucket DEST_BUCKET`**: Optional. The name of the InfluxDB bucket in the destination server, must not be an already existing bucket. Defaults to value of `--src-bucket` or `None` if `--src-bucket` not provided.
 
-**`--dest-host DEST_HOST`**: The host for the destination server. Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or https://some-domain:8086.
+**`--dest-host DEST_HOST`**: The host for the destination server. Must have a scheme, domain or IP address, and port, e.g., `http://127.0.0.1:8086` or `https://<domain>:<port>`.
 
 **`--dest-org DEST_ORG`**: Optional. The name of the organization to restore buckets to in the destination server. If this is omitted, then all migrated buckets from the source server will retain their original organization and migrated buckets may not be visible in the destination server without creating and switching organizations. This value will be used in all forms of restoration whether a single bucket, a full migration, or any migration using csv files for backup and restoration.
 

--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -134,7 +134,7 @@ The following is a formatted version of the output:
 
 **`--src-bucket SRC_BUCKET`**: Optional. The name of the InfluxDB bucket in the source server. If not provided, then `--full` must be provided.
 
-**`--src-host SRC_HOST`**: Optional. The host for the source server. Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or https://<domain>:<port>. Defaults to http://localhost:8086b if no value is specified.
+**`--src-host SRC_HOST`**: Optional. The host for the source server. Must have a scheme, domain or IP address, and port, e.g., `http://127.0.0.1:8086` or `https://<domain>:<port>`. Defaults to http://localhost:8086 if no value is specified.
 
 > As mentioned previously, `mountpoint-s3` and `rclone` are needed if `--s3-bucket` is to be used, but can be ignored if the user doesn't provide a value for `--s3-bucket`, in which case backup files will be stored in a unique directory locally.
 

--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -152,7 +152,7 @@ After meeting the prerequisites:
 
     b. Listing buckets with `influx bucket list -t <destination token> --host <destination host address> --skip-verify`.
 
-    c. Using `influx v1 shell -t <destination token> --host <destination host address> --skip-verify` and running `SELECT * FROM <migrated bucket>.<retention period>.<measurement name> LIMIT 100` to view contents of a bucket or `SELECT COUNT(*) FROM <migrated bucket>.<retention period>.<measurment name>` to verify the correct number of records have been migrated.
+    c. Using `influx v1 shell -t <destination token> --host <destination host address> --skip-verify` and running `SELECT * FROM <migrated bucket>.<retention period>.<measurement name> LIMIT 100` to view contents of a bucket or `SELECT COUNT(*) FROM <migrated bucket>.<retention period>.<measurement name>` to verify the correct number of records have been migrated.
 
     d. By running a query using `influx query -t <destination token> --host <destination host address> --skip-verify 'from(bucket: "<migrated bucket>") |> range(start: <desired start>, stop: <desired stop>)'`. Adding `|> count()` to the query is also a way to verify the correct number of records have been migrated.
 

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -280,6 +280,14 @@ def health_check(host, token, skip_verify, debug=False):
         client = InfluxDBClient(url=host,
             token=token, timeout=MILLISECOND_TIMEOUT, verify_ssl=not skip_verify, debug=debug)
         if not client.ping():
+            url_parse = urllib.parse.urlparse(host)
+            if url_parse.scheme == "":
+                logging.error("Host is missing scheme")
+            if url_parse.port is None:
+                logging.error("Host is missing port")
+            if url_parse.scheme == "" or url_parse.port is None:
+                logging.error("The expected format for host urls is <scheme>:<domain>:<port>. "
+                    "For example, http://127.0.0.1:8086")
             raise InfluxDBError(message=f"InfluxDB API call to {host}/ping failed")
     except InfluxDBError as error:
         logging.error(str(error))

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -378,11 +378,11 @@ def parse_args(args):
         required=False)
     parser.add_argument("--src-host", help="Optional. The host for the source server. "
         "Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or "
-        "https://some-domain:8086. Defaults to http://localhost:8086.",
+        "https://<domain>:<port>. Defaults to http://localhost:8086 if no value is specified.",
         default="http://localhost:8086", required=False)
     parser.add_argument("--dest-host", help="The host for the destination server. "
         "Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or "
-        "https://some-domain:8086.",
+        "https://<domain:<port>.",
         required=True)
     parser.add_argument("--full", help="Optional. Whether to perform a full restore, replacing all "
         "data on destination server with all data from source server from all organizations, "

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -373,7 +373,7 @@ def parse_args(args):
         "source server. If not provided, then --full must be provided.",
         required=False)
     parser.add_argument("--dest-bucket", help="Optional. The name of the InfluxDB bucket in the "
-        "destination server, must not be an already existing bucket. Defaults to value of"
+        "destination server, must not be an already existing bucket. Defaults to value of "
         "--src-bucket or None if --src-bucket not provided.",
         required=False)
     parser.add_argument("--src-host", help="Optional. The host for the source server. Defaults to "

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -376,11 +376,13 @@ def parse_args(args):
         "destination server, must not be an already existing bucket. Defaults to value of "
         "--src-bucket or None if --src-bucket not provided.",
         required=False)
-    parser.add_argument("--src-host", help="Optional. The host for the source server. Defaults to "
-        "http://localhost:8086.",
+    parser.add_argument("--src-host", help="Optional. The host for the source server. "
+        "Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or "
+        "https://some-domain:8086. Defaults to http://localhost:8086.",
         default="http://localhost:8086", required=False)
-    parser.add_argument("--dest-host", help="The host for the destination server. Example: "
-        "http://localhost:8086.",
+    parser.add_argument("--dest-host", help="The host for the destination server. "
+        "Must have a scheme, domain or IP address, and port, e.g., http://127.0.0.1:8086 or "
+        "https://some-domain:8086.",
         required=True)
     parser.add_argument("--full", help="Optional. Whether to perform a full restore, replacing all "
         "data on destination server with all data from source server from all organizations, "

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -280,7 +280,7 @@ def health_check(host, token, skip_verify):
         client = InfluxDBClient(url=host,
             token=token, timeout=MILLISECOND_TIMEOUT, verify_ssl=not skip_verify)
         if not client.ping():
-            raise InfluxDBError(message=f"{host} ping failed")
+            raise InfluxDBError(message=f"InfluxDB API call to {host}/ping failed")
     except InfluxDBError as error:
         logging.error(str(error))
         return False


### PR DESCRIPTION
Changes:
- The help messages for `--src-host` and `--dest-host` have been updated to specify the expected url formatting.
- The error log when a health check fails has been changed to indicate that it is an API call failure.
- A confusing comment in a code block in the README has been fixed.
- A typo in the README has been fixed.