### PR TITLE
Verify number of series migrated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node_modules
 # Ignore AWS Influx migration script backup and performance files and directories
 tools/python/influx-migration/**/performance.txt
 tools/python/influx-migration/**/*influxdb-backup-*
+tools/python/influx-migration/**/scripts/temp/*

--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -651,3 +651,17 @@ Possible reasons for a restore failing include:
 - Invalid InfluxDB destination token.
 - A bucket existing in the destination instance with the same name as in the source instance. For individual bucket migrations use the `--dest-bucket` option to set a unique name for the migrated bucket.
 - Connectivity failure, either with the source or destination hosts or with an optional S3 bucket.
+
+### Determining Amount of Data Migrated
+
+By default, the number of shards migrated, as reported by the Influx CLI, and the
+number of rows migrated when `--csv` is used, are logged.
+When the log level is set to `debug`, with the option `--log-level debug`, the
+number of [series](https://docs.influxdata.com/influxdb/v2/reference/key-concepts/data-elements/#series) as reported by
+the [InfluxDB `/metrics` endpoint](https://docs.influxdata.com/influxdb/v2/api/#operation/GetMetrics), under [bucket series number](https://docs.influxdata.com/influxdb/v2/reference/internals/metrics/#bucket-series-number),
+will be logged.
+
+If a bucket is empty or has not been migrated, it will not be listed under bucket series number and an error indicating as such will be logged.
+This can help determine whether data is successfully being migrated.
+
+To manually verify migrated records, see the recommended queries listed in the [Migration Overview](#migration-overview) section, step 3.

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -685,7 +685,7 @@ def set_logging(log_level):
     
     logging.addLevelName(logging.WARNING, yellow + logging.getLevelName(logging.WARNING) + reset)
     logging.addLevelName(logging.ERROR, bold_red + logging.getLevelName(logging.ERROR) + reset)
-    log_format = '%(levelname)s: %(filename)s: %(message)s'
+    log_format = '%(levelname)s: %(asctime)s %(filename)s: %(message)s'
 
     log_level = log_level.lower()
     if log_level == "debug":

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -256,17 +256,26 @@ def bucket_exists(host, token, bucket_name, skip_verify=False, org_name=None):
                 logging.debug(f"{len(org_list)} orgs matched with name {org_name}")
             bucket = client.buckets_api().find_bucket_by_name(bucket_name)
             if bucket is None:
+                logging.debug(f"Bucket with name {bucket_name} could not be found "
+                    f"in host {host}")
                 return False
             if len(org_list) > 0:
                 for org in org_list:
                     if org.id == bucket.org_id:
+                        logging.debug(f"Bucket with name {bucket_name} found in org "
+                            f"{org_name} with org ID {org.id} in host {host}")
                         return True
                 # Bucket could not be found in any org with matching org_name
+                logging.debug(f"Bucket with name {bucket_name} could not be found "
+                    f"in any org with name {org_name} in host {host}")
                 return False
             # Org not specified and bucket has been found
+            logging.debug(f"Bucket with name {bucket_name} found in host {host}")
             return True
     except InfluxDBError as error:
         logging.error(str(error))
+        logging.debug("An unexpected error occurred while checking the existence "
+            f"a bucket with name {bucket_name} in host {host}")
         return False
 
 def cleanup(mount_point=None, exec_s3_bucket_mount=None):

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -174,9 +174,9 @@ def backup_csv(backup_path, root_token, src_host, bucket_name=None, full=False, 
     if logging.root.level >= logging.DEBUG:
         time.sleep(METRICS_SCRAPE_INTERVAL_SECONDS)
         if full:
-            report_all_bucket_series_count(host=src_host, token=root_token, org=src_org)
+            report_all_bucket_series_count(host=src_host, token=root_token, org_name=src_org)
         else:
-            report_bucket_series_count(bucket_name=bucket_name, host=src_host, token=root_token, org=src_org)
+            report_bucket_series_count(bucket_name=bucket_name, host=src_host, token=root_token, org_name=src_org)
     start_time = time.time()
 
     try:

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -50,8 +50,7 @@ MILLISECOND_TIMEOUT = 30_000
 # mount an S3 bucket
 MOUNT_POINT_NAME = "influxdb-backups"
 
-# The recommended amount of time to wait before scraping from the /metrics endpoint
-# to ensure metrics are up to date
+# The number of seconds to wait before scraping from the /metrics endpoint
 METRICS_SCRAPE_INTERVAL_SECONDS=10
 
 BUCKET_PAGINATION_LIMIT=100

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -35,12 +35,12 @@ from sys import platform
 import textwrap
 import time
 import urllib
-from influxdb_client.service.metrics_service import MetricsService
 import urllib3
 
 from influxdb_client import BucketRetentionRules, InfluxDBClient
 from influxdb_client.client.exceptions import InfluxDBError
 from influxdb_client.rest import ApiException
+from influxdb_client.service.metrics_service import MetricsService
 
 # Maximum number of retries for attempting to mount an S3 bucket
 MAX_RETRIES = 20

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -116,18 +116,14 @@ def report_all_bucket_series_count(host, token, org_name=None):
         if org_name is not None:
             client.org = org_name
         buckets = client.buckets_api().find_buckets(limit=BUCKET_PAGINATION_LIMIT)
-        for bucket in buckets.buckets:
-            if not bucket.name.startswith("_"):
-                report_bucket_series_count(bucket_name=bucket.name, host=host, token=token, org_name=org_name)
-        # Handle pagination
         offset = 0
-        while buckets.links.next is not None:
-            offset += BUCKET_PAGINATION_LIMIT
-            buckets = client.buckets_api().find_buckets(limit=BUCKET_PAGINATION_LIMIT,
-                offset=offset)
+        while len(buckets.buckets) > 0:
             for bucket in buckets.buckets:
                 if not bucket.name.startswith("_"):
                     report_bucket_series_count(bucket_name=bucket.name, host=host, token=token, org_name=org_name)
+            offset += BUCKET_PAGINATION_LIMIT
+            buckets = client.buckets_api().find_buckets(limit=BUCKET_PAGINATION_LIMIT,
+                offset=offset)
 
 def report_bucket_series_count(bucket_name, host, token, org_name=None):
     try:

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -257,15 +257,12 @@ def bucket_exists(host, token, bucket_name, org_name=None, skip_verify=False):
                 logging.debug(f"Bucket with name {bucket_name} could not be found "
                     f"in host {host}")
                 return False
-            logging.debug(f"Bucket with name {bucket_name} found in host {host}")
-            if org_name is not None:
-                logging.debug(f"Bucket found in org with name {org_name} and ID {buckets.buckets[0].org_id}")
             logging.debug(f"{len(buckets.buckets)} buckets found")
+            for bucket in buckets.buckets:
+                logging.debug(f"Bucket with name {bucket_name} found in "
+                    f"host {host} in org with ID {bucket.org_id}")
             return True
     except InfluxDBError as error:
-        logging.error(str(error))
-        logging.debug("An unexpected error occurred while checking the existence "
-            f"a bucket with name {bucket_name} in host {host}")
         return False
 
 def cleanup(mount_point=None, exec_s3_bucket_mount=None):


### PR DESCRIPTION
- The series count of buckets to be backed up are now logged when log level is set to `debug`.
- The series count of buckets after restoration up are now logged when log level is set to `debug`.
- `bucket_exists` has been improved.
- All logs now include a timestamp.
- Documentation describing how series counts are logged has been added.
- `scripts/temp` has been added to `.gitignore`.