### PR TITLE
Upgrade Flink Connector Dependency

### DIFF
--- a/integrations/flink_connector/README.md
+++ b/integrations/flink_connector/README.md
@@ -59,13 +59,62 @@ mvn clean compile && mvn package
 cd ../sample-kinesis-to-timestream-app
 aws s3 cp target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar s3://YOUR_BUCKET_NAME/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar
 ```
-3. Follow the steps in [Create and Run the Kinesis Data Analytics Application](https://docs.aws.amazon.com/kinesisanalytics/latest/java/get-started-exercise.html#get-started-exercise-7)
- - pick Apache Flink version 1.13.2
- - in "Edit the IAM Policy" step, add Timestream Write permissions to the created policy
+3. In the AWS Console, navigate to [Managed Apache Flink](https://console.aws.amazon.com/flink/home) to create the Apache Flink application
+ - Choose `Apache Flink Applications` in the navigation side bar
+ - Choose `Create streaming application`
+ - pick Apache Flink version 1.18
+ - Enter an application name and optional description
+ - Choose `Create streaming application`
 
-4. Follow **Getting Started** section from [sample data generator](/integrations/flink_connector/sample-data-generator) to send records to Kinesis.
-5. The records now should be consumed by the sample application and written to Timestream table.
-6. Query Timestream table using [AWS Console](https://docs.aws.amazon.com/timestream/latest/developerguide/console_timestream.html#console_timestream.queries.using-console) or AWS CLI:
+4. In the `Application details` pane of your new application
+ - Choose `IAM role` to add add the required permissions to the application role
+ - From the IAM Role of your application, choose the `Policy name` for the policy
+ - From the selected policy, choose `Edit`
+ - Append the following permissions to the role policy `Statement` and replace `<region>` with the region of your deployed application, and replace `<account-id>` with the AWS account id:
+
+    ```json
+        {
+          "Effect": "Allow",
+          "Action": [
+            "timestream:CreateDatabase"
+          ],
+          "Resource": "arn:aws:timestream:<region>:<account-id>:database/kdaflink"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "timestream:WriteRecords",
+            "timestream:CreateTable"
+          ],
+          "Resource": "arn:aws:timestream:<region>:<account-id>:database/kdaflink/table/kinesisdata"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "timestream:DescribeEndpoints"
+          ],
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "kinesis:GetShardIterator",
+            "kinesis:GetRecords",
+            "kinesis:ListShards"
+          ],
+          "Resource": "arn:aws:kinesis:<region>:<account-id>:stream/TimestreamTestStream"
+        }
+    ```
+
+5. From the `Apache Flink applications` page, choose the application you previously created
+6. Choose `Configure`
+7. Under `Amazon S3 bucket` in `Application Code Location`, choose the S3 bucket that you uploaded the application to in `Step 2`
+8. Under `Path to S3 object`, input the path to the application jar file
+9. Choose `Save changes`
+10. Choose `Run` and choose `Rune` again
+11. Follow **Getting Started** section from [sample data generator](/integrations/flink_connector/sample-data-generator) to send records to Kinesis.
+12. The records now should be consumed by the sample application and written to Timestream table.
+13. Query Timestream table using [AWS Console](https://docs.aws.amazon.com/timestream/latest/developerguide/console_timestream.html#console_timestream.queries.using-console) or AWS CLI:
 ```
 aws timestream-query query --query-string "SELECT * FROM kdaflink.kinesisdata WHERE time >= ago (15m) LIMIT 10"
 ```

--- a/integrations/flink_connector/README.md
+++ b/integrations/flink_connector/README.md
@@ -67,10 +67,10 @@ aws s3 cp target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar s3://YOUR_BUC
  - Choose `Create streaming application`
 
 4. In the `Application details` pane of your new application
- - Choose `IAM role` to add add the required permissions to the application role
- - From the IAM Role of your application, choose the `Policy name` for the policy
+ - Choose `IAM role` to add the required permissions to the application role
+ - From the IAM Role of your application, choose the `Policy name`
  - From the selected policy, choose `Edit`
- - Append the following permissions to the role policy `Statement` and replace `<region>` with the region of your deployed application, and replace `<account-id>` with the AWS account id:
+ - Append the following permissions to the role policy `Statement`, replacing `<region>` with the region of your deployed application and `<account-id>` with the AWS account ID:
 
     ```json
         {
@@ -108,10 +108,10 @@ aws s3 cp target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar s3://YOUR_BUC
 
 5. From the `Apache Flink applications` page, choose the application you previously created
 6. Choose `Configure`
-7. Under `Amazon S3 bucket` in `Application Code Location`, choose the S3 bucket that you uploaded the application to in `Step 2`
+7. Under `Amazon S3 bucket` in `Application Code Location`, choose the S3 bucket that the application was uploaded to in `Step 2`
 8. Under `Path to S3 object`, input the path to the application jar file
 9. Choose `Save changes`
-10. Choose `Run` and choose `Rune` again
+10. Choose `Run` and choose `Run` again
 11. Follow **Getting Started** section from [sample data generator](/integrations/flink_connector/sample-data-generator) to send records to Kinesis.
 12. The records now should be consumed by the sample application and written to Timestream table.
 13. Query Timestream table using [AWS Console](https://docs.aws.amazon.com/timestream/latest/developerguide/console_timestream.html#console_timestream.queries.using-console) or AWS CLI:

--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -29,7 +29,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.17.1</flink.version>
+        <flink.version>1.18.1</flink.version>
+        <guava.version>33.2.1-jre</guava.version>
         <java.version>1.11</java.version>
         <jdk.version>11</jdk.version>
         <next.jdk.version>12</next.jdk.version>
@@ -90,6 +91,12 @@ under the License.
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
             <version>2.20.101</version>
+       </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/integrations/flink_connector/flink-connector-timestream/src/main/java/com/amazonaws/samples/connectors/timestream/TimestreamModelUtils.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/main/java/com/amazonaws/samples/connectors/timestream/TimestreamModelUtils.java
@@ -1,6 +1,6 @@
 package com.amazonaws.samples.connectors.timestream;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Utf8;
+import com.google.common.base.Utf8;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
@@ -1,8 +1,10 @@
 package com.amazonaws.samples.connectors.timestream;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -125,5 +127,20 @@ public class SinkInitContext implements InitContext {
 
     public SinkWriterMetricGroup getSinkMetricGroup() {
         return this.sinkMetricGroup;
+    }
+
+    @Override
+    public <IN> TypeSerializer<IN> createInputSerializer() {
+        return null;
+    }
+
+    @Override
+    public JobID getJobId() {
+        return null;
+    }
+
+    @Override
+    public boolean isObjectReuseEnabled() {
+        return false;
     }
 }

--- a/integrations/flink_connector/sample-data-generator/README.md
+++ b/integrations/flink_connector/sample-data-generator/README.md
@@ -5,7 +5,8 @@ This folder contains a script to generate a continuous stream of records that ar
 --- 
 ## Dependencies
 - Boto3
-- numpy (Tested with version 1.18.5)
+- distutils
+- numpy (Tested with version 2.0.0)
 - Python3 (Tested with version 3.5.2)
 
 ----
@@ -27,7 +28,13 @@ python3 -m venv venv
    pip3 install numpy
    ```
 
-3. Run the following command to continuously generate and ingest sample data into Kinesis.
+3. Install  setuptools
+
+  ```
+  pip3 install setuptools
+  ```
+
+4. Run the following command to continuously generate and ingest sample data into Kinesis.
 
     ```    
     python3 kinesis_data_gen.py --stream <name_of_the_kinesis_stream> --region <the_region_of_kinesis_stream> 

--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
@@ -29,7 +29,7 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.15.3</flink.version>
+        <flink.version>1.16.3</flink.version>
         <kda.version>2.0.0</kda.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <java.version>1.11</java.version>


### PR DESCRIPTION
Issue #, if available: N/A

N/A

Description of changes:

Upgrade flink dependency for Timestream Flink connector. Update documentation for running application with flink 1.18 on Managed Apache Flink. Revisions to `SinkInitContext.java` required for new API changes with the upgrade. The `sample-kinesis-to-timestream-app` is only upgraded to `1.16.3` as is the latest version available for `flink-connector-kinesis` on [maven2](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-kinesis/).

Validations:
- [x] - flink-connector-timestream compiles
  - Execute command: `mvn clean compile`
- [x] - flink-connector-timestream tests pass
  - Execute command: `mvn test`
- [x] - sample-kinesis-to-timestream-app compiles
  - Execute command: `mvn clean compile`
- [x] - sample-kinesis-to-timestream-app tests pass
  - Execute command: `mvn test`
- [x] - sample-kinesis-to-timestream-app  ran on Managed Apache Flink and flink 1.18 can ingest to Timestream
  - Complete the following:
    - `cd ../sample-kinesis-to-timestream-app`
    - `mvn clean compile && mvn package` 
    - `aws s3 cp target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar s3://YOUR_BUCKET_NAME/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar`
    - Create application in Managed Apache Flink
    - Configure application as per README
    - Run application
    - Ingest data to kinesis stream using data generator
    - Validate data is ingested to Timestream without any application errors in Manage Apache Flink
- [x] - sample-kinesis-to-timestream-app ran locally can ingest to Timestream
  - Execute the following commands:
    - `mvn clean compile && mvn package`
    - `mvn install exec:java -Dexec.mainClass="com.amazonaws.samples.kinesis2timestream.StreamingJob" -Dexec.args="--InputStreamName TimestreamTestStream --Region us-east-1 --TimestreamDbName kdaflink --TimestreamTableName kinesisdata" -Dexec.classpathScope=test`
- [x] - sample-data-generator can ingest to kinesis stream
  - Execute command: `python3 kinesis_data_gen.py --stream TimestreamTestStream --region us-east-1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
