### PR TITLE
Revise Flink Dependency with Sample Connector Application

### DIFF
--- a/integrations/flink_connector/README.md
+++ b/integrations/flink_connector/README.md
@@ -100,7 +100,8 @@ aws s3 cp target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar s3://YOUR_BUC
           "Action": [
             "kinesis:GetShardIterator",
             "kinesis:GetRecords",
-            "kinesis:ListShards"
+            "kinesis:ListShards",
+            "kinesis:DescribeStream"
           ],
           "Resource": "arn:aws:kinesis:<region>:<account-id>:stream/TimestreamTestStream"
         }

--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -64,7 +64,7 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-base</artifactId>
             <version>${flink.version}</version>
-      </dependency>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-core</artifactId>

--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <artifactId>flink-connector-timestream</artifactId>
     <groupId>com.amazonaws.samples.connectors.timestream</groupId>
-    <version>0.3-SNAPSHOT</version>
+    <version>0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>flink-connector-timestream</name>
@@ -33,6 +33,7 @@ under the License.
         <guava.version>33.2.1-jre</guava.version>
         <java.version>1.11</java.version>
         <jdk.version>11</jdk.version>
+        <awssdk.version>2.26.9</awssdk.version>
         <next.jdk.version>12</next.jdk.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -43,7 +44,7 @@ under the License.
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.20.101</version>
+                <version>${awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,6 +63,11 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-base</artifactId>
+            <version>${flink.version}</version>
+      </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
             <version>${flink.version}</version>
         </dependency>
 
@@ -85,12 +91,13 @@ under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>timestreamwrite</artifactId>
+            <version>${awssdk.version}</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
-            <version>2.20.101</version>
+            <version>${awssdk.version}</version>
        </dependency>
 
         <dependency>

--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/README.md
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/README.md
@@ -33,7 +33,7 @@ mvn clean compile && mvn package
 
 You can run the application on your local environment by running `StreamingJobs` class:
 ```
-mvn install exec:java -Dexec.mainClass="com.amazonaws.samples.kinesis2timestream.StreamingJob" -Dexec.args="--InputStreamName TimestreamTestStream --Region us-east-1 --TimestreamDbName kdaflink --TimestreamTableName kinesisdata" -Dexec.classpathScope=test
+java -jar target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar --InputStreamName TimestreamTestStream --Region us-east-1 --TimestreamDbName kdaflink --TimestreamTableName kinesisdata
 ```
 
 In another terminal, concurrently, run the [python sample data generator](../sample-data-generator).

--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
@@ -29,7 +29,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.16.3</flink.version>
+        <flink.version>1.18.1</flink.version>
+        <flink.kinesis.version>4.2.0-1.18</flink.kinesis.version>
         <kda.version>2.0.0</kda.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <java.version>1.11</java.version>
@@ -38,6 +39,7 @@ under the License.
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <log4j.version>2.17.1</log4j.version>
+        <slf4j.version>2.0.12</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -45,7 +47,7 @@ under the License.
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.203</version>
+                <version>2.26.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -73,27 +75,28 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-java</artifactId>
             <version>${flink.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients</artifactId>
             <version>${flink.version}</version>
-            <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
         <!-- Add connector dependencies here. They must be in the default scope (compile). -->
         <!-- For reading from Kinesis -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.kinesis.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -115,13 +118,13 @@ under the License.
         <dependency>
             <groupId>software.amazon.timestream</groupId>
             <artifactId>flink-connector-timestream</artifactId>
-            <version>0.3</version>
+            <version>0.5</version>
         </dependency>
-
         <!-- sdk dependencies -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>timestreamwrite</artifactId>
+            <version>2.26.9</version>
         </dependency>
 
         <!-- Test & compile dependencies -->
@@ -149,13 +152,12 @@ under the License.
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId> slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.32</version>
-            <scope>runtime</scope>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>de.javakaffee</groupId>
@@ -233,7 +235,6 @@ under the License.
                                 <excludes>
                                     <exclude>org.apache.flink:force-shading</exclude>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>
-                                    <exclude>org.slf4j:*</exclude>
                                     <exclude>log4j:*</exclude>
                                 </excludes>
                             </artifactSet>

--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
@@ -70,7 +70,6 @@ under the License.
 
     <dependencies>
         <!-- Apache Flink dependencies -->
-        <!-- These dependencies are provided, because they should not be packaged into the JAR file. -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-java</artifactId>


### PR DESCRIPTION
Issue #, if available: N/A

N/A

Description of changes:

Upgrade flink dependency for Timestream Flink connector. Update documentation for running application with flink 1.18.1 on Managed Apache Flink. Revisions to `SinkInitContext.java` required for new API changes with the upgrade. The sample kinesis application jar now has all dependencies to execute without additional runtime configurations.

## How to test

- Execute the following under `flink-connector-timestream`: `mvn clean compile && mvn package && mvn install`
- Update the `pom.xml` in `sample-kinesis-to-timestream-app` `flink-connector-timestream` dependency to the following:
```xml
        <dependency>
            <groupId>com.amazonaws.samples.connectors.timestream</groupId>
            <artifactId>flink-connector-timestream</artifactId>
            <version>0.5-SNAPSHOT</version>
      </dependency>
```
- Execute the following under `sample-kinesis-to-timestream-app` to build the jar: `mvn clean compile && mvn package`
- Execute the following under `sample`kinesis-to-timestream-app` to execute the jar file: `java -jar target/sample-kinesis-to-timestream-app-0.1-SNAPSHOT.jar --InputStreamName TimestreamTestStream --Region us-east-1 --TimestreamDbName kdaflink --TimestreamTableName kinesisdata`
- Execute the following under `sample-data-generator` to ingest data to the kinesis stream: `python3 kinesis_data_gen.py --stream TimestreamTestStream --region us-east-1`
- Validate data is being ingested to the `kinesisdata` table in the `kdaflink` database in region `us-east-1` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
