### PR TITLE
Add pre-commit hook for secrets scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/awslabs/git-secrets
+    rev: 5357e18bc27b42a827b6780564ea873a72ca1f01
+    hooks:
+      - id: git-secrets
+        entry: /usr/bin/env
+        args:
+          # Using a bash script to ensure aws secrets rules is always installed.
+          - bash
+          - -c
+          - echo "Using aws secrets rules" && git-secrets --register-aws && git-secrets --pre_commit_hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,11 @@ repos:
           # Using a bash script to ensure aws secrets rules is always installed.
           - bash
           - -c
-          - echo "Scanning with aws-secrets" && git-secrets --register-aws && git-secrets --pre_commit_hook
+          - |
+            echo "Scanning with git-secrets..."
+            git-secrets --register-aws
+            if ! git-secrets --pre_commit_hook; then
+              echo "Error: Potential secrets detected. Please review your changes."
+              exit 1
+            fi
+            echo "No secrets detected."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: git-secrets
         entry: /usr/bin/env
+        verbose: True
         args:
           # Using a bash script to ensure aws secrets rules is always installed.
           - bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
           # Using a bash script to ensure aws secrets rules is always installed.
           - bash
           - -c
-          - echo "Using aws secrets rules" && git-secrets --register-aws && git-secrets --pre_commit_hook
+          - echo "Scanning with aws-secrets" && git-secrets --register-aws && git-secrets --pre_commit_hook

--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -1,0 +1,17 @@
+# Amazon Timestream Tools and Samples Developer Guide
+
+## Pre-Commit Hook
+
+A pre-commit hook configuration is provided in the `.pre-commit-config.yaml` file.
+
+This pre-commit hook is configured to scan for secrets with [`git-secrets`](https://github.com/awslabs/git-secrets), to make sure no secrets are committed to this repository.
+
+To use the pre-commit hook:
+
+1. Install [`pre-commit`](https://pre-commit.com/#install).
+2. In the root of this repository, run;
+    ```
+    pre-commit install
+    ```
+3. Now, whenever `git commit` is run, `aws-secrets` will scan for secrets.
+

--- a/DEVELOPER_README.md
+++ b/DEVELOPER_README.md
@@ -13,5 +13,5 @@ To use the pre-commit hook:
     ```
     pre-commit install
     ```
-3. Now, whenever `git commit` is run, `aws-secrets` will scan for secrets.
+3. Now, whenever `git commit` is run, `git-secrets` will scan for secrets.
 


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

- A pre-commit hook has been added that uses `aws-secrets` in order to prevent secrets from being committed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
