### PR TITLE
Add SAM template

### DIFF
--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
@@ -493,22 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws_lambda_events"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7319a086b79c3ff026a33a61e80f04fd3885fbb73237981ea080d21944e1cb1c"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-serde",
- "query_map",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,9 +573,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bytes-utils"
@@ -785,15 +766,6 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1247,9 +1219,10 @@ dependencies = [
  "aws-types",
  "chrono",
  "influxdb-line-protocol",
- "lambda_http",
+ "lambda_runtime",
  "rand",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -1266,33 +1239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "lambda_http"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fe279be7f89f5f72c97c3a96f45c43db8edab1007320ecc6a5741273b4d6db"
-dependencies = [
- "aws_lambda_events",
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-body-util",
- "hyper 1.4.1",
- "lambda_runtime",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio-stream",
- "url",
 ]
 
 [[package]]
@@ -1406,12 +1352,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1596,17 +1536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "query_map"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eab6b8b1074ef3359a863758dae650c7c0c6027927a085b7af911c8e0bf3a15"
-dependencies = [
- "form_urlencoded",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -1911,18 +1840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -3,10 +3,10 @@ name = "influxdb-timestream-connector"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies.lambda_http]
+[dependencies.lambda_runtime]
 version = "0.13.0"
 default-features = false
-features = ["apigw_http", "apigw_rest", "anyhow", "tracing"]
+features = ["anyhow", "tracing"]
 
 [dependencies]
 anyhow = "1.0.86"
@@ -20,6 +20,7 @@ chrono = "0.4.38"
 influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "d81f63ddc10e3cf1c28b05e6c1cef03b71da7f8a" }
 rand = "0.5.0"
 serde = { version = "1.0.208", features = ["derive"] }
+serde_json = "1.0.1"
 tokio = { version = "1.39.3", features = ["full"] }
 
 [package.metadata.lambda.env]

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies.lambda_http]
 version = "0.13.0"
 default-features = false
-features = ["apigw_http", "anyhow", "tracing"]
+features = ["apigw_http", "apigw_rest", "anyhow", "tracing"]
 
 [dependencies]
 anyhow = "1.0.86"

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -273,6 +273,42 @@ To configure the sample application and ingest all line protocol data contained 
 | `ServiceQuotaExceededException` | 400 | The instance quota of resource exceeded for this account. | Confirm you are not exceeding Timestream for LiveAnalytics' quotas. If you are not exceeding any quotas, check the list of [line protocol limitations](#line-protocol-limitations) below, specifically the number of unique measurement names. |
 | `ThrottlingException` | 400 | Too many requests were made by a user and they exceeded the service quotas. The request was throttled. | Decrease the rate of your requests. |
 
+## Testing
+
+### Requirements
+
+1. [Configure your AWS credentials for use by the AWS SDK for Rust](https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html).
+2. Ensure your IAM permissions contain the permissions listed in 
+
+### Integration Tests
+
+To run all integration tests, use the following command, from the project root:
+
+```shell
+cargo test --test '*' -- --test-threads=1
+```
+
+> **NOTE**: It is important to use the flag `--test-threads=1` in order to avoid throttling errors, as the integration tests will create and delete tables.
+
+To run a specific integration test, use the following command:
+
+```shell
+cargo test <integration test name>
+```
+
+### Unit Tests
+
+To run all unit tests, use the following command:
+
+```shell
+cargo test --lib
+```
+
+To run a single unit test, use the following command:
+
+```shell
+cargo test <unit test name>
+```
 
 ## Limitations
 
@@ -293,6 +329,10 @@ Due to the connector translating line protocol to Timestream records, line proto
 | Maximum unique field key values. | 1024 |
 | Latest valid timestamp. | Fifteen minutes in the future from the current time. |
 | Oldest valid timestamp. | `mag_store_retention_period` days before the current time. |
+
+### Database and Table Creation Delay
+
+There is a delay of one second added before deleting or creating a table or database. This is because of Timestream for LiveAnalytics' "Throttle rate for CRUD APIs" [quota](https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.default) of one table/database deletion/creation per second.
 
 ## Caveats
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -86,6 +86,19 @@ The following parameters are available when deploying the connector as part of a
     ```
 6. Once the stack has finished deploying, take note of the output `Endpoint` value. This value will be used as the endpoint for all write requests and is analogous to an [InfluxDB host address](https://docs.influxdata.com/influxdb/v2/reference/urls/) and is used in the same way, for example, `<endpoint>/api/v2/write`.
 
+#### Lambda Dead Letter Queue
+
+If the connector was deployed with async invocation, then all client requests will be returned a response with a `202` status code, indicating that the request has been received and is being processed. If the request fails, the client will not be notified. Instead, failed requests will either be [logged by the REST API Gateway](#viewing-rest-api-gateway-logs) or be added to the Lambda's dead letter queue, where the failed request can be reviewed in full. The name of the dead letter queue is provided as the `LambdaDeadLetterQueueName` output when deploying the stack.
+
+To access the Lambda's dead letter queue and view any possible stored messages:
+
+1. Take note of the dead letter queue's name as provided by the `LambdaDeadLetterQueueName` output upon successful stack deployment.
+2. Visit the [Amazon SQS console](https://console.aws.amazon.com/sqs/v3/home).
+3. In the navigation pane, choose **Queues**.
+4. Find and select the SQS queue with the same name as indicated by `LambdaDeadLetterQueueName`.
+5. Choose **Send and receive messages**.
+6. Choose **Poll for messages**.
+
 #### Stack Logs
 
 ##### Viewing REST API Gateway Logs

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -14,7 +14,7 @@ The following diagram shows a high-level overview of the connector's architectur
 
 ### Multi-Table Multi-Measure
 
-The following table shows how the connector maps line protocol elements to Timestream for LiveAnalytics record elements.
+The following table shows how the connector maps line protocol elements to Timestream for LiveAnalytics record attributes.
 
 | Line Protocol Element | Timestream Record Attribute |
 |-----------------------|---------------------------|
@@ -23,7 +23,7 @@ The following table shows how the connector maps line protocol elements to Times
 | Fields                | Measures                  |
 | Measurements          | Table names               |
 
-A Timestream record's `measure_name` field is not derived from any element of ingested line protocol. Due to the multi-measure record translation, the connector sets the `measure_name` for each multi-measure record to the value of a Lambda environment variable.
+A Timestream record's `measure_name` field is not derived from any element of ingested line protocol. Due to the multi-measure record translation, the connector sets the `measure_name` for each multi-measure record to the value of a Lambda environment variable. When [deployed as part of a CloudFormation stack](#aws-cloudformation-deployment), this can be customized by overriding the `MeasureNameForMultiMeasureRecords` parameter. When [deployed locally](#local-deployment), this can be customized by setting the `measure_name_for_multi_measure_records` environment variable.
 
 The following example shows the translation of a single line protocol point into a Timestream for LiveAnalytics table, using a Timestamp with second precision and a Lambda environment variable configured to `influxdb-measure`:
 
@@ -47,30 +47,57 @@ The InfluxDB Timestream connector can be deployed within an AWS CloudFormation s
 
 #### Deploying a CloudFormation Stack Using SAM CLI
 
-The stack can be deployed using the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) and `template.yml`.
+The stack can be deployed using the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/using-sam-cli.html), [Cargo Lambda](https://www.cargo-lambda.info/) to package the code, and `template.yml`.
 
-1. Run the following command replacing `<region>` with the AWS region you want to deploy in and provide parameter overrides as desired:
+##### Stack Parameters
+
+The following parameters are available when deploying the connector as part of a CloudFormation stack. An example of setting these parameters is included in step 4 of the [SAM deployment steps](#sam-deployment-steps).
+
+| Parameter     | Description | Default Value |
+|---------------|-------------|---------------|
+| `DatabaseName`  | The name of the database to use for ingestion. | `influxdb-line-protocol` |
+| `LambdaMemorySize` | The size of the memory in MB allocated per invocation of the function. | `512` |
+| `LambdaName` | The name to use for the Lambda function. | `influxdb-timestream-connector-lambda` |
+| `LambdaTimeoutInSeconds` | The number of seconds to run the Lambda function before timing out. | `30` |
+| `MeasureNameForMultiMeasureRecords` | The value to use in records as the `measure_name`, as shown in the [example line protocol to Timestream records translation](#resulting-cpu_load_short-timestream-for-liveanalytics-table). | `influxdb-measure` |
+| `RestApiGatewayName` | The name to use for the REST API Gateway. | `InfluxDB-Timestream-Connector-REST-API-Gateway` |
+| `RestApiGatewayStageName` | The name to use for the REST API Gateway stage. | `dev` |
+| `RestApiGatewayTimeoutInMillis` | The maximum number of milliseconds a REST API Gateway event will wait before timing out. | `30000` |
+| `WriteThrottlingBurstLimit` | The number of burst requests per second that the REST API Gateway permits. | `1200` |
+
+##### SAM Deployment Steps
+
+1. [Download and install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html).
+2. [Download and install Rust](https://www.rust-lang.org/tools/install).
+3. [Download and install Cargo Lambda](https://www.cargo-lambda.info/guide/installation.html).
+4. Run the following command to package the binary in `target/lambda/influxdb-timestream-connector/bootstrap.zip`, where `template.yml` expects it to be, and cross compile for Linux ARM:
+    ```
+    cargo lambda build --release --arm64 --output-format zip
+    ```
+5. Run the following command, replacing `<region>` with the AWS region you want to deploy in, `<stack name>` with your desired stack name and providing parameter overrides as desired. Note that this example command uses `--resolve-s3` to automatically create an S3 bucket to use for packaging and deployment and `--capabilities CAPABILITY_IAM` to allow the creation of IAM roles.
 
     ```shell
-    sam --region <region> --parameter-overrides ParameterKey=exampleKey,ParameterValue=exampleValue deploy template.yml
+    sam deploy template.yml \
+        --region <region> \
+        --stack-name <stack name> \
+        --resolve-s3 \
+        --capabilities CAPABILITY_IAM \
+        --parameter-overrides ParameterKey=exampleKey,ParameterValue=exampleValue
     ```
-2. Once the stack has finished deploying, take note of the output "Endpoint" value. This value will be used as the endpoint for all write requests, for example, `<endpoint>/api/v2/write`.
+6. Once the stack has finished deploying, take note of the output `Endpoint` value. This value will be used as the endpoint for all write requests and is analogous to an [InfluxDB host address](https://docs.influxdata.com/influxdb/v2/reference/urls/) and is used in the same way, for example, `<endpoint>/api/v2/write`.
 
 #### Stack Logs
 
 ##### Viewing REST API Gateway Logs
 
-By default, execution and access logging is enabled for the REST API Gateway.
+By default, execution logging is enabled for the REST API Gateway.
 
 To view logs:
 
 1. Visit the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home).
 2. In the navigation pane, choose **Stacks**.
 3. Choose your deployed stack from the list of stacks.
-4. In the **Resources** tab choose the **Physical ID** of the REST API Gateway.
-5. In the navigation pane, under **Monitor**, choose **Logging**.
-6. From the dropdown menu, select the currently deployed stage.
-7. Choose **View logs in CloudWatch**.
+4. In the **Resources** tab choose the **Physical ID** of the `RestApiGatewayLogGroup` resource.
 
 ##### Viewing Lambda Logs
 
@@ -89,17 +116,18 @@ To view logs:
 The connector can be run locally using [Cargo Lambda](https://www.cargo-lambda.info/guide/what-is-cargo-lambda.html).
 
 1. [Download and install Rust](https://www.rust-lang.org/tools/install).
-2. [Download and install Cargo Lambda](https://www.cargo-lambda.info/guide/installation.html).
-3. Configure the following environment variables:
+2. [Configure your AWS credentials for use by the AWS SDK for Rust](https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html).
+3. [Download and install Cargo Lambda](https://www.cargo-lambda.info/guide/installation.html).
+4. Configure the following environment variables:
     - `region` string: the AWS region to use. Defaults to `us-east-1`.
     - `database_name` string: the Timestream for LiveAnalytics database name to use. Defaults to `influxdb-line-protocol`.
     - `measure_name_for_multi_measure_records` string: the value to use in records as the measure name. Defaults to `influxdb-measure`.
-4. To run the connector on `http://localhost:9000` execute the following command:
+5. To run the connector on `http://localhost:9000` execute the following command:
 
     ```shell
     cargo lambda watch
     ```
-5. Send all requests to `http://localhost:9000/api/v2/write`.
+6. Send all requests to `http://localhost:9000/api/v2/write`.
 
 ## Security
 
@@ -203,7 +231,10 @@ To configure the sample application and ingest all line protocol data contained 
 5. Run the sample Go client:
     - With the connector deployed in a CloudFormation stack, replacing `<region>` with the AWS region you deployed your stack in and `<endpoint>` with the endpoint of your deployed REST API Gateway:
         ```shell
-        go run line-protocol-client-demo.go --region <region> --service execute-api --endpoint <endpoint>
+        go run line-protocol-client-demo.go \
+            --region <region> \
+            --service execute-api \
+            --endpoint <endpoint>
         ```
     - With the connector deployed locally:
         ```shell

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -278,7 +278,15 @@ To configure the sample application and ingest all line protocol data contained 
 ### Requirements
 
 1. [Configure your AWS credentials for use by the AWS SDK for Rust](https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html).
-2. Ensure your IAM permissions contain the permissions listed in 
+2. Ensure your IAM permissions include the permissions listed in the [IAM Execution Permissions](#iam-execution-permissions) section.
+
+### All Tests
+
+To run all tests, including integration tests and unit tests, use the following command:
+
+```shell
+cargo test -- --test-threads=1
+```
 
 ### Integration Tests
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -299,3 +299,8 @@ Due to the connector translating line protocol to Timestream records, line proto
 ### Line Protocol Tag Requirement
 
 In order to ingest to Timestream for LiveAnalytics, every line protocol point must include at least one tag.
+
+### Query String Parameters
+
+The connector expects query string parameters to be included as `queryParameters` or `queryStringParameters` in requests.
+

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -90,7 +90,7 @@ The following parameters are available when deploying the connector as part of a
 
 ##### Viewing REST API Gateway Logs
 
-By default, execution logging is enabled for the REST API Gateway.
+By default, access logging is enabled for the REST API Gateway.
 
 To view logs:
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -56,7 +56,7 @@ The following parameters are available when deploying the connector as part of a
 | Parameter     | Description | Default Value |
 |---------------|-------------|---------------|
 | `DatabaseName`  | The name of the database to use for ingestion. | `influxdb-line-protocol` |
-| `LambdaMemorySize` | The size of the memory in MB allocated per invocation of the function. | `512` |
+| `LambdaMemorySize` | The size of the memory in MB allocated per invocation of the function. | `128` |
 | `LambdaName` | The name to use for the Lambda function. | `influxdb-timestream-connector-lambda` |
 | `LambdaTimeoutInSeconds` | The number of seconds to run the Lambda function before timing out. | `30` |
 | `MeasureNameForMultiMeasureRecords` | The value to use in records as the `measure_name`, as shown in the [example line protocol to Timestream records translation](#resulting-cpu_load_short-timestream-for-liveanalytics-table). | `influxdb-measure` |

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -110,10 +110,6 @@ pub async fn lambda_handler(
             .header("content-type", "text/html")
             .body(Body::Empty)
             .map_err(Box::new)?),
-        Err(error) => Ok(Response::builder()
-            .status(400)
-            .header("content-type", "text/html")
-            .body(Body::Text(error.to_string()))
-            .map_err(Box::new)?),
+        Err(error) => Err(anyhow!(error.to_string())),
     }
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -129,7 +129,14 @@ pub async fn lambda_handler(
         .as_bytes();
 
     match handle_body(client, data, &precision).await {
-        Ok(_) => Ok(json!({ "status": 200, "body": "" })),
+        Ok(_) => Ok(json!({
+            "statusCode": 200,
+            "body": "{\"message\": \"Success\"}",
+            "isBase64Encoded": false,
+            "headers": {
+                "Content-Type": "application/json"
+            }
+        })),
         Err(error) => Err(anyhow!(error.to_string())),
     }
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -95,7 +95,7 @@ pub fn get_precision(event: &Value) -> Option<&str> {
             if let Some(precision_str) = precision.as_str() {
                 return Some(precision_str);
             // event["queryStringParameters"]["precision"] may be an array. This is common from requests
-            // originating form AWS services, such as when the connector is ran with the cargo lambda watch command
+            // originating from AWS services, such as when the connector is ran with the cargo lambda watch command
             } else if let Some(precision_array) = precision.as_array() {
                 if let Some(precision_value) = precision_array.first().and_then(|value| value.as_str()) {
                     return Some(precision_value);

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
@@ -1,15 +1,16 @@
 use influxdb_timestream_connector::{
     lambda_handler, records_builder::validate_env_variables, timestream_utils::get_connection,
 };
-use lambda_http::{run, service_fn, tracing, Error as lambda_error, Request};
+use lambda_runtime::{run, service_fn, tracing, Error, LambdaEvent};
+use serde_json::Value;
 
 #[tokio::main]
-async fn main() -> Result<(), lambda_error> {
+async fn main() -> Result<(), Error> {
     validate_env_variables()?;
     let region = std::env::var("region")?;
     let timestream_client = get_connection(&region).await?;
     tracing::init_default_subscriber();
-    run(service_fn(|event: Request| {
+    run(service_fn(|event: LambdaEvent<Value>| {
         lambda_handler(&timestream_client, event)
     }))
     .await

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -1,0 +1,284 @@
+Transform: AWS::Serverless-2016-10-31
+
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: influxdb-timestream-connector
+    Description: This serverless application deployes an AWS Lambda function and an Amazon REST API Gateway that listens for POST requests with line protocol bodies. The line protocol data will be translated and stored in Timestream for LiveAnalytics. This application allows configuration over the resources it creates.
+    Author: Amazon Timestream
+    SpdxLicenseId: MIT-0
+    #LicenseUrl: LICENSE TODO: Fix path and reference an S3 bucket for SAR deployment
+    #ReadmeUrl: README.md TODO: Fix path and reference an S3 bucket for SAR deployment
+    HomePageUrl: https://aws.amazon.com/timestream/
+    SemanticVersion: 1.0.0
+
+Parameters:
+  DatabaseName:
+    Type: String
+    Default: influxdb-line-protocol
+    Description: The Timestream for LiveAnalytics database name to use.
+  MeasureNameForMultiMeasureRecords:
+    Type: String
+    Default: influxdb-measure
+    Description: The value to use in records as the measure name.
+  EnableDatabaseCreation:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+  EnableTableCreation:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+  EnableMagStoreWrites:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'true'
+  MagStoreRetentionPeriod:
+    Type: Number
+    Default: 8000
+  MemStoreRetentionPeriod:
+    Type: Number
+    Default: 12
+  RestApiGatewayName:
+    Type: String
+    Default: InfluxDB-Timestream-Connector-REST-API-Gateway
+  RestApiGatewayStageName:
+    Type: String
+    Default: dev
+    Description: The default stage name of the REST API Gateway.
+  LambdaMemorySize:
+    Type: Number
+    Default: 512
+    MinValue: 128
+    MaxValue: 8192
+    Description: The memory size of the Lambda function.
+  LambdaName:
+    Type: String
+    AllowedPattern: '[a-zA-Z0-9]+[a-zA-Z0-9-]+[a-zA-Z0-9]+'
+    Default: influxdb-timestream-connector-lambda
+  RestApiGatewayTimeoutInMillis:
+    Type: Number
+    MinValue: 2
+    Default: 30000
+    Description: The maximum amount of time in milliseconds an API Gateway event will wait before timing out.
+  LambdaTimeoutInSeconds:
+    Type: Number
+    MinValue: 3
+    Default: 30
+    Description: The amount of time in seconds to run the connector on AWS Lambda before timing out.
+  WriteThrottlingBurstLimit:
+    Type: Number
+    Default: 1200
+    Description: The number of burst requests per second that the REST API Gateway permits.
+
+Resources:
+  RestApiGateway:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: !Ref RestApiGatewayName
+
+  ApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt RestApiGateway.RootResourceId
+      PathPart: api
+      RestApiId: !Ref RestApiGateway
+
+  V2Resource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref ApiResource
+      PathPart: v2
+      RestApiId: !Ref RestApiGateway
+
+  WriteResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref V2Resource
+      PathPart: write
+      RestApiId: !Ref RestApiGateway
+
+  RestApiGatewayPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      ResourceId: !Ref WriteResource
+      RestApiId: !Ref RestApiGateway
+      AuthorizationType: AWS_IAM
+      HttpMethod: POST
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub
+          - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
+          - LambdaArn: !GetAtt LambdaFunction.Arn
+      MethodResponses:
+        - StatusCode: 200
+          ResponseModels:
+            application/json: Empty
+
+  RestApiGatewayDeployment:
+    Type: AWS::ApiGateway::Deployment
+    DependsOn: RestApiGatewayPostMethod
+    Properties:
+      RestApiId: !Ref RestApiGateway
+
+  RestApiGatewayStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: !Ref RestApiGatewayStageName
+      RestApiId: !Ref RestApiGateway
+      DeploymentId: !Ref RestApiGatewayDeployment
+      MethodSettings:
+        - DataTraceEnabled: true
+          HttpMethod: "*"
+          ResourcePath: "/*"
+          LoggingLevel: INFO
+          MetricsEnabled: true
+      AccessLogSetting:
+        DestinationArn: !GetAtt RestApiGatewayLogGroup.Arn
+        Format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","user":"$context.identity.user","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","errorMessage":"$context.error.message"}'
+      TracingEnabled: true
+      Variables:
+        lambdaAlias: !Ref RestApiGatewayStageName
+
+  RestApiGatewayUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    DependsOn: RestApiGatewayStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref RestApiGateway
+          Stage: !Ref RestApiGatewayStageName
+      Throttle:
+        BurstLimit: !Ref WriteThrottlingBurstLimit
+
+  RestApiGatewayLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/apigateway/${RestApiGatewayName}"
+      RetentionInDays: 14
+
+  RestApiGatewayLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+
+  RestApiGatewayLogAccount:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn: !GetAtt RestApiGatewayLogsRole.Arn
+
+  LambdaDeadLetterQueue:
+    Type: AWS::SQS::Queue
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+      Policies:
+        - PolicyName: LambdaLogPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Effect: Allow
+                Resource:
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaName}:*
+        - PolicyName: LambdaSQSDlqPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                - sqs:SendMessage
+                Effect: Allow
+                Resource: !GetAtt LambdaDeadLetterQueue.Arn
+        - PolicyName: LambdaTimestreamDescribeEndpointsPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                - timestream:DescribeEndpoints
+                Effect: Allow
+                Resource: "*"
+        - PolicyName: LambdaTimestreamWritePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                - timestream:DescribeTable
+                - timestream:WriteRecords
+                - timestream:CreateTable
+                Effect: Allow
+                Resource: !Sub arn:aws:timestream:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}/table/*
+        - PolicyName: LambdaTimestreamDatabasePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                - timestream:DescribeDatabase
+                - timestream:CreateDatabase
+                Effect: Allow
+                Resource: !Sub arn:aws:timestream:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}
+
+  LambdaFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: provided.al2023
+      Handler: influxdb-timestream-connector
+      Architectures:
+        - arm64
+      CodeUri: ./target/lambda/influxdb-timestream-connector/bootstrap.zip
+      FunctionName: !Ref LambdaName
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt LambdaDeadLetterQueue.Arn
+      Events:
+        RestApiGatewayEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref RestApiGateway
+            Path: /api/v2/write
+            Method: POST
+      Environment:
+        Variables:
+          database_name: !Ref DatabaseName
+          measure_name_for_multi_measure_records: !Ref MeasureNameForMultiMeasureRecords
+          region: !Ref AWS::Region
+          enable_database_creation: !Ref EnableDatabaseCreation
+          enable_table_creation: !Ref EnableTableCreation
+          enable_mag_store_writes: !Ref EnableMagStoreWrites
+          mag_store_retention_period: !Ref MagStoreRetentionPeriod
+          mem_store_retention_period: !Ref MemStoreRetentionPeriod
+          RUST_LOG: trace
+      PackageType: Zip
+      Timeout: !Ref LambdaTimeoutInSeconds
+      MemorySize: !Ref LambdaMemorySize
+
+Outputs:
+  Endpoint:
+    Value: !Sub https://${RestApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${RestApiGatewayStageName}
+

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -113,23 +113,211 @@ Resources:
       Integration:
         IntegrationHttpMethod: POST
         Type: AWS
-        PassthroughBehavior: NEVER
+        PassthroughBehavior: WHEN_NO_MATCH
         RequestTemplates:
           text/plain: |
             {
-              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+              "resource": "$context.resourcePath",
+              "path": "$context.path",
+              "httpMethod": "$context.httpMethod",
+              "body" : "$util.escapeJavaScript($input.body)",
+              "headers": {
+                #foreach($param in $input.params().header.keySet())
+                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "queryStringParameters": {
+                #foreach($param in $input.params().querystring.keySet())
+                "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "pathParameters": {
+                #foreach($param in $input.params().path.keySet())
+                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "requestContext": {
+                "accountId": "$context.identity.accountId",
+                "resourceId": "$context.resourceId",
+                "stage": "$context.stage",
+                "requestId": "$context.requestId",
+                "requestTimeEpoch": "$context.requestTimeEpoch",
+                "identity": {
+                  "cognitoIdentityPoolId": "$context.identity.cognitoIdentityPoolId",
+                  "accountId": "$context.identity.accountId",
+                  "cognitoIdentityId": "$context.identity.cognitoIdentityId",
+                  "caller": "$context.identity.caller",
+                  "apiKey": "$context.apiKey",
+                  "sourceIp": "$context.identity.sourceIp",
+                  "cognitoAuthenticationType": "$context.identity.cognitoAuthenticationType",
+                  "cognitoAuthenticationProvider": "$context.identity.cognitoAuthenticationProvider",
+                  "userArn": "$context.identity.userArn",
+                  "userAgent": "$context.identity.userAgent",
+                  "user": "$context.identity.user"
+                },
+                "resourcePath": "$context.resourcePath",
+                "httpMethod": "$context.httpMethod",
+                "apiId": "$context.apiId"
+              },
+              "stageVariables": {
+                #foreach($key in $stageVariables.keySet())
+                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
+                #end
+              },
+              "isBase64Encoded": false
             }
           text/plain; charset=utf-8: |
             {
-              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+              "resource": "$context.resourcePath",
+              "path": "$context.path",
+              "httpMethod": "$context.httpMethod",
+              "body" : "$util.escapeJavaScript($input.body)",
+              "headers": {
+                #foreach($param in $input.params().header.keySet())
+                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "queryStringParameters": {
+                #foreach($param in $input.params().querystring.keySet())
+                "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "pathParameters": {
+                #foreach($param in $input.params().path.keySet())
+                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "requestContext": {
+                "accountId": "$context.identity.accountId",
+                "resourceId": "$context.resourceId",
+                "stage": "$context.stage",
+                "requestId": "$context.requestId",
+                "requestTimeEpoch": "$context.requestTimeEpoch",
+                "identity": {
+                  "cognitoIdentityPoolId": "$context.identity.cognitoIdentityPoolId",
+                  "accountId": "$context.identity.accountId",
+                  "cognitoIdentityId": "$context.identity.cognitoIdentityId",
+                  "caller": "$context.identity.caller",
+                  "apiKey": "$context.apiKey",
+                  "sourceIp": "$context.identity.sourceIp",
+                  "cognitoAuthenticationType": "$context.identity.cognitoAuthenticationType",
+                  "cognitoAuthenticationProvider": "$context.identity.cognitoAuthenticationProvider",
+                  "userArn": "$context.identity.userArn",
+                  "userAgent": "$context.identity.userAgent",
+                  "user": "$context.identity.user"
+                },
+                "resourcePath": "$context.resourcePath",
+                "httpMethod": "$context.httpMethod",
+                "apiId": "$context.apiId"
+              },
+              "stageVariables": {
+                #foreach($key in $stageVariables.keySet())
+                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
+                #end
+              },
+              "isBase64Encoded": false
             }
           text/csv: |
             {
-              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+              "resource": "$context.resourcePath",
+              "path": "$context.path",
+              "httpMethod": "$context.httpMethod",
+              "body" : "$util.escapeJavaScript($input.body)",
+              "headers": {
+                #foreach($param in $input.params().header.keySet())
+                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "queryStringParameters": {
+                #foreach($param in $input.params().querystring.keySet())
+                "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "pathParameters": {
+                #foreach($param in $input.params().path.keySet())
+                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "requestContext": {
+                "accountId": "$context.identity.accountId",
+                "resourceId": "$context.resourceId",
+                "stage": "$context.stage",
+                "requestId": "$context.requestId",
+                "requestTimeEpoch": "$context.requestTimeEpoch",
+                "identity": {
+                  "cognitoIdentityPoolId": "$context.identity.cognitoIdentityPoolId",
+                  "accountId": "$context.identity.accountId",
+                  "cognitoIdentityId": "$context.identity.cognitoIdentityId",
+                  "caller": "$context.identity.caller",
+                  "apiKey": "$context.apiKey",
+                  "sourceIp": "$context.identity.sourceIp",
+                  "cognitoAuthenticationType": "$context.identity.cognitoAuthenticationType",
+                  "cognitoAuthenticationProvider": "$context.identity.cognitoAuthenticationProvider",
+                  "userArn": "$context.identity.userArn",
+                  "userAgent": "$context.identity.userAgent",
+                  "user": "$context.identity.user"
+                },
+                "resourcePath": "$context.resourcePath",
+                "httpMethod": "$context.httpMethod",
+                "apiId": "$context.apiId"
+              },
+              "stageVariables": {
+                #foreach($key in $stageVariables.keySet())
+                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
+                #end
+              },
+              "isBase64Encoded": false
             }
           application/json: |
             {
-              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+              "path": "$context.path",
+              "headers": {
+                #foreach($param in $input.params().header.keySet())
+                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "pathParameters": {
+                #foreach($param in $input.params().path.keySet())
+                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "resource": "$context.resourcePath",
+              "httpMethod": "$context.httpMethod",
+              "body": "$util.escapeJavaScript($input.body)",
+              "queryStringParameters": {
+                #foreach($param in $input.params().querystring.keySet())
+                "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
+                #end
+              },
+              "requestContext": {
+                "accountId": "$context.identity.accountId",
+                "resourceId": "$context.resourceId",
+                "stage": "$context.stage",
+                "requestId": "$context.requestId",
+                "requestTimeEpoch": "$context.requestTimeEpoch",
+                "identity": {
+                  "cognitoIdentityPoolId": "$context.identity.cognitoIdentityPoolId",
+                  "accountId": "$context.identity.accountId",
+                  "cognitoIdentityId": "$context.identity.cognitoIdentityId",
+                  "caller": "$context.identity.caller",
+                  "apiKey": "$context.apiKey",
+                  "sourceIp": "$context.identity.sourceIp",
+                  "cognitoAuthenticationType": "$context.identity.cognitoAuthenticationType",
+                  "cognitoAuthenticationProvider": "$context.identity.cognitoAuthenticationProvider",
+                  "userArn": "$context.identity.userArn",
+                  "userAgent": "$context.identity.userAgent",
+                  "user": "$context.identity.user"
+                },
+                "resourcePath": "$context.resourcePath",
+                "httpMethod": "$context.httpMethod",
+                "apiId": "$context.apiId"
+              },
+              "stageVariables": {
+                #foreach($key in $stageVariables.keySet())
+                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
+                #end
+              },
+              "isBase64Encoded": false
             }
         Uri: !Sub
           - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
@@ -175,7 +363,7 @@ Resources:
       AccessLogSetting:
         DestinationArn: !GetAtt RestApiGatewayLogGroup.Arn
         Format: |
-          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","contentType":"$context.requestOverride.header.Content-Type","caller":"$context.identity.caller","user":"$context.identity.user","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","errorMessage":"$context.error.message"}
+          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","user":"$context.identity.user","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","errorMessage":"$context.error.message"}
       TracingEnabled: true
       Variables:
         lambdaAlias: !Ref RestApiGatewayStageName

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -165,23 +165,12 @@ Resources:
         RequestTemplates:
           text/plain: |
             {
-              "resource": "$context.resourcePath",
               "path": "$context.path",
               "httpMethod": "$context.httpMethod",
               "body" : "$util.escapeJavaScript($input.body)",
-              "headers": {
-                #foreach($param in $input.params().header.keySet())
-                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
               "queryStringParameters": {
                 #foreach($param in $input.params().querystring.keySet())
                 "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
-              "pathParameters": {
-                #foreach($param in $input.params().path.keySet())
-                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
                 #end
               },
               "requestContext": {
@@ -206,33 +195,17 @@ Resources:
                 "resourcePath": "$context.resourcePath",
                 "httpMethod": "$context.httpMethod",
                 "apiId": "$context.apiId"
-              },
-              "stageVariables": {
-                #foreach($key in $stageVariables.keySet())
-                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
-                #end
               },
               "isBase64Encoded": false
             }
           text/plain; charset=utf-8: |
             {
-              "resource": "$context.resourcePath",
               "path": "$context.path",
               "httpMethod": "$context.httpMethod",
               "body" : "$util.escapeJavaScript($input.body)",
-              "headers": {
-                #foreach($param in $input.params().header.keySet())
-                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
               "queryStringParameters": {
                 #foreach($param in $input.params().querystring.keySet())
                 "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
-              "pathParameters": {
-                #foreach($param in $input.params().path.keySet())
-                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
                 #end
               },
               "requestContext": {
@@ -257,33 +230,17 @@ Resources:
                 "resourcePath": "$context.resourcePath",
                 "httpMethod": "$context.httpMethod",
                 "apiId": "$context.apiId"
-              },
-              "stageVariables": {
-                #foreach($key in $stageVariables.keySet())
-                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
-                #end
               },
               "isBase64Encoded": false
             }
           text/csv: |
             {
-              "resource": "$context.resourcePath",
               "path": "$context.path",
               "httpMethod": "$context.httpMethod",
               "body" : "$util.escapeJavaScript($input.body)",
-              "headers": {
-                #foreach($param in $input.params().header.keySet())
-                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
               "queryStringParameters": {
                 #foreach($param in $input.params().querystring.keySet())
                 "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
-              "pathParameters": {
-                #foreach($param in $input.params().path.keySet())
-                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
                 #end
               },
               "requestContext": {
@@ -308,30 +265,14 @@ Resources:
                 "resourcePath": "$context.resourcePath",
                 "httpMethod": "$context.httpMethod",
                 "apiId": "$context.apiId"
-              },
-              "stageVariables": {
-                #foreach($key in $stageVariables.keySet())
-                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
-                #end
               },
               "isBase64Encoded": false
             }
           application/json: |
             {
               "path": "$context.path",
-              "headers": {
-                #foreach($param in $input.params().header.keySet())
-                "$param": "$util.escapeJavaScript($input.params().header.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
-              "pathParameters": {
-                #foreach($param in $input.params().path.keySet())
-                "$param": "$util.escapeJavaScript($input.params().path.get($param))" #if($foreach.hasNext),#end
-                #end
-              },
-              "resource": "$context.resourcePath",
               "httpMethod": "$context.httpMethod",
-              "body": "$util.escapeJavaScript($input.body)",
+              "body" : "$util.escapeJavaScript($input.body)",
               "queryStringParameters": {
                 #foreach($param in $input.params().querystring.keySet())
                 "$param": "$util.escapeJavaScript($input.params().querystring.get($param))" #if($foreach.hasNext),#end
@@ -359,11 +300,6 @@ Resources:
                 "resourcePath": "$context.resourcePath",
                 "httpMethod": "$context.httpMethod",
                 "apiId": "$context.apiId"
-              },
-              "stageVariables": {
-                #foreach($key in $stageVariables.keySet())
-                "$key": "$util.escapeJavaScript($stageVariables.get($key))" #if($foreach.hasNext),#end
-                #end
               },
               "isBase64Encoded": false
             }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -6,8 +6,8 @@ Metadata:
     Description: This serverless application deployes an AWS Lambda function and an Amazon REST API Gateway that listens for POST requests with line protocol bodies. The line protocol data will be translated and stored in Timestream for LiveAnalytics. This application allows configuration over the resources it creates.
     Author: Amazon Timestream
     SpdxLicenseId: MIT-0
-    #LicenseUrl: LICENSE TODO: Fix path and reference an S3 bucket for SAR deployment
-    #ReadmeUrl: README.md TODO: Fix path and reference an S3 bucket for SAR deployment
+    LicenseUrl: ../../../LICENSE
+    ReadmeUrl: ./README.md
     HomePageUrl: https://aws.amazon.com/timestream/
     SemanticVersion: 1.0.0
 
@@ -587,5 +587,10 @@ Resources:
   
 Outputs:
   Endpoint:
+    Description: The endpoint for the REST API Gateway.
     Value: !Sub https://${RestApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${RestApiGatewayStageName}
+  LambdaDeadLetterQueueName:
+    Description: The name of the dead letter queue used by the Lambda function.
+    Condition: IsAsyncEnabled
+    Value: !GetAtt LambdaDeadLetterQueue.QueueName
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -63,10 +63,6 @@ Parameters:
     MinValue: 128
     MaxValue: 8192
     Description: The memory size of the Lambda function.
-  LambdaName:
-    Type: String
-    AllowedPattern: '[a-zA-Z0-9]+[a-zA-Z0-9-]+[a-zA-Z0-9]+'
-    Default: influxdb-timestream-connector-lambda
   RestApiGatewayTimeoutInMillis:
     Type: Number
     MinValue: 2
@@ -90,7 +86,7 @@ Resources:
   RestApiGateway:
     Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: !Ref RestApiGatewayName
+      Name: !Sub "${RestApiGatewayName}-${AWS::StackId}"
 
   ApiResource:
     Type: AWS::ApiGateway::Resource
@@ -396,7 +392,7 @@ Resources:
   RestApiGatewayLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/apigateway/${RestApiGatewayName}"
+      LogGroupName: !Sub "/aws/apigateway/${RestApiGateway.RestApiId}"
       RetentionInDays: 14
 
   RestApiGatewayLogsRole:
@@ -443,7 +439,7 @@ Resources:
                   - logs:PutLogEvents
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${LambdaName}:*
+                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
         - PolicyName: LambdaSQSDlqPolicy
           PolicyDocument:
             Version: 2012-10-17
@@ -489,7 +485,6 @@ Resources:
       Architectures:
         - arm64
       CodeUri: ./target/lambda/influxdb-timestream-connector/bootstrap.zip
-      FunctionName: !Ref LambdaName
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt LambdaDeadLetterQueue.Arn

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -112,12 +112,45 @@ Resources:
       HttpMethod: POST
       Integration:
         IntegrationHttpMethod: POST
-        Type: AWS_PROXY
+        Type: AWS
+        PassthroughBehavior: NEVER
+        RequestTemplates:
+          text/plain: |
+            {
+              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+            }
+          text/plain; charset=utf-8: |
+            {
+              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+            }
+          text/csv: |
+            {
+              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+            }
+          application/json: |
+            {
+              "body": "$util.escapeJavaScript($input.body).replaceAll(\"\\'\", \"'\")"
+            }
         Uri: !Sub
           - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
           - LambdaArn: !GetAtt LambdaFunction.Arn
+        RequestParameters:
+          integration.request.header.X-Amz-Invocation-Type: "'Event'"
+        IntegrationResponses:
+          - StatusCode: 500
+            SelectionPattern: '.*'
+            ResponseTemplates:
+              application/json: |
+                {
+                  "error": "Internal error",
+                  "message": "$util.escapeJavaScript($input.path('$.errorMessage'))"
+                }
+          - StatusCode: 202
       MethodResponses:
-        - StatusCode: 200
+        - StatusCode: 500
+          ResponseModels:
+            application/json: Error
+        - StatusCode: 202 # Accepted but not yet processed
           ResponseModels:
             application/json: Empty
 
@@ -141,7 +174,8 @@ Resources:
           MetricsEnabled: true
       AccessLogSetting:
         DestinationArn: !GetAtt RestApiGatewayLogGroup.Arn
-        Format: '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","user":"$context.identity.user","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","errorMessage":"$context.error.message"}'
+        Format: |
+          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","contentType":"$context.requestOverride.header.Content-Type","caller":"$context.identity.caller","user":"$context.identity.user","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","errorMessage":"$context.error.message"}
       TracingEnabled: true
       Variables:
         lambdaAlias: !Ref RestApiGatewayStageName
@@ -263,6 +297,13 @@ Resources:
             RestApiId: !Ref RestApiGateway
             Path: /api/v2/write
             Method: POST
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt LambdaDeadLetterQueue.Arn
+        MaximumEventAgeInSeconds: 3600
+        MaximumRetryAttempts: 0
       Environment:
         Variables:
           database_name: !Ref DatabaseName
@@ -276,7 +317,7 @@ Resources:
       PackageType: Zip
       Timeout: !Ref LambdaTimeoutInSeconds
       MemorySize: !Ref LambdaMemorySize
-
+  
 Outputs:
   Endpoint:
     Value: !Sub https://${RestApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${RestApiGatewayStageName}

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -20,6 +20,12 @@ Parameters:
     Type: String
     Default: influxdb-measure
     Description: The value to use in records as the measure name.
+  EnableAsyncInvocation:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
   EnableDatabaseCreation:
     Type: String
     AllowedValues:
@@ -76,6 +82,10 @@ Parameters:
     Default: 1200
     Description: The number of burst requests per second that the REST API Gateway permits.
 
+Conditions:
+  IsAsyncEnabled: !Equals [ !Ref EnableAsyncInvocation, "true" ]
+  IsSyncEnabled: !Equals [ !Ref EnableAsyncInvocation, "false" ]
+
 Resources:
   RestApiGateway:
     Type: AWS::ApiGateway::RestApi
@@ -103,13 +113,51 @@ Resources:
       PathPart: write
       RestApiId: !Ref RestApiGateway
 
-  RestApiGatewayPostMethod:
+  SyncRestApiGatewayPostMethod:
     Type: AWS::ApiGateway::Method
+    Condition: IsSyncEnabled
     Properties:
       ResourceId: !Ref WriteResource
       RestApiId: !Ref RestApiGateway
       AuthorizationType: AWS_IAM
       HttpMethod: POST
+      ApiKeyRequired: false
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub
+          - arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
+          - LambdaArn: !GetAtt LambdaFunction.Arn
+        IntegrationResponses:
+          - StatusCode: '200'
+            SelectionPattern: '2\d{2}'
+            ResponseTemplates:
+              application/json: |
+                {
+                  "statusCode": 200,
+                  "body": "$input.body"
+                }
+          - StatusCode: '500'
+            SelectionPattern: '5\d{2}'
+            ResponseTemplates:
+              application/json: |
+                {
+                  "statusCode": "Internal error",
+                  "error": "$util.escapeJavaScript($input.path('$.errorMessage'))"
+                }
+      MethodResponses:
+        - StatusCode: '200' # Synchronous response, success
+        - StatusCode: '500'
+
+  AsyncRestApiGatewayPostMethod:
+    Type: AWS::ApiGateway::Method
+    Condition: IsAsyncEnabled
+    Properties:
+      ResourceId: !Ref WriteResource
+      RestApiId: !Ref RestApiGateway
+      AuthorizationType: AWS_IAM
+      HttpMethod: POST
+      ApiKeyRequired: false
       Integration:
         IntegrationHttpMethod: POST
         Type: AWS
@@ -325,35 +373,32 @@ Resources:
         RequestParameters:
           integration.request.header.X-Amz-Invocation-Type: "'Event'"
         IntegrationResponses:
-          - StatusCode: 500
-            SelectionPattern: '.*'
-            ResponseTemplates:
-              application/json: |
-                {
-                  "error": "Internal error",
-                  "message": "$util.escapeJavaScript($input.path('$.errorMessage'))"
-                }
-          - StatusCode: 202
+          - StatusCode: '202'
       MethodResponses:
-        - StatusCode: 500
-          ResponseModels:
-            application/json: Error
-        - StatusCode: 202 # Accepted but not yet processed
-          ResponseModels:
-            application/json: Empty
+        - StatusCode: '202' # Asynchronous response, accepted but not yet processed
 
-  RestApiGatewayDeployment:
+  AsyncRestApiGatewayDeployment:
     Type: AWS::ApiGateway::Deployment
-    DependsOn: RestApiGatewayPostMethod
+    Condition: IsAsyncEnabled
+    DependsOn: AsyncRestApiGatewayPostMethod
     Properties:
       RestApiId: !Ref RestApiGateway
 
-  RestApiGatewayStage:
+  SyncRestApiGatewayDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Condition: IsSyncEnabled
+    DependsOn: SyncRestApiGatewayPostMethod
+    Properties:
+      RestApiId: !Ref RestApiGateway
+
+  AsyncRestApiGatewayStage:
     Type: AWS::ApiGateway::Stage
+    Condition: IsAsyncEnabled
+    DependsOn: AsyncRestApiGatewayDeployment
     Properties:
       StageName: !Ref RestApiGatewayStageName
       RestApiId: !Ref RestApiGateway
-      DeploymentId: !Ref RestApiGatewayDeployment
+      DeploymentId: !Ref AsyncRestApiGatewayDeployment
       MethodSettings:
         - DataTraceEnabled: true
           HttpMethod: "*"
@@ -368,9 +413,43 @@ Resources:
       Variables:
         lambdaAlias: !Ref RestApiGatewayStageName
 
-  RestApiGatewayUsagePlan:
+  SyncRestApiGatewayStage:
+    Type: AWS::ApiGateway::Stage
+    Condition: IsSyncEnabled
+    DependsOn: SyncRestApiGatewayDeployment
+    Properties:
+      StageName: !Ref RestApiGatewayStageName
+      RestApiId: !Ref RestApiGateway
+      DeploymentId: !Ref SyncRestApiGatewayDeployment
+      MethodSettings:
+        - DataTraceEnabled: true
+          HttpMethod: "*"
+          ResourcePath: "/*"
+          LoggingLevel: INFO
+          MetricsEnabled: true
+      AccessLogSetting:
+        DestinationArn: !GetAtt RestApiGatewayLogGroup.Arn
+        Format: |
+          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","caller":"$context.identity.caller","user":"$context.identity.user","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","errorMessage":"$context.error.message"}
+      TracingEnabled: true
+      Variables:
+        lambdaAlias: !Ref RestApiGatewayStageName
+
+  AsyncRestApiGatewayUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
-    DependsOn: RestApiGatewayStage
+    Condition: IsAsyncEnabled
+    DependsOn: AsyncRestApiGatewayStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref RestApiGateway
+          Stage: !Ref RestApiGatewayStageName
+      Throttle:
+        BurstLimit: !Ref WriteThrottlingBurstLimit
+
+  SyncRestApiGatewayUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    Condition: IsSyncEnabled
+    DependsOn: SyncRestApiGatewayStage
     Properties:
       ApiStages:
         - ApiId: !Ref RestApiGateway

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -86,7 +86,7 @@ Resources:
   RestApiGateway:
     Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: !Sub "${RestApiGatewayName}-${AWS::StackId}"
+      Name: !Sub "${RestApiGatewayName}-${AWS::StackName}"
 
   ApiResource:
     Type: AWS::ApiGateway::Resource

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -59,7 +59,7 @@ Parameters:
     Description: The default stage name of the REST API Gateway.
   LambdaMemorySize:
     Type: Number
-    Default: 512
+    Default: 128
     MinValue: 128
     MaxValue: 8192
     Description: The memory size of the Lambda function.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -273,7 +273,6 @@ Resources:
           enable_mag_store_writes: !Ref EnableMagStoreWrites
           mag_store_retention_period: !Ref MagStoreRetentionPeriod
           mem_store_retention_period: !Ref MemStoreRetentionPeriod
-          RUST_LOG: trace
       PackageType: Zip
       Timeout: !Ref LambdaTimeoutInSeconds
       MemorySize: !Ref LambdaMemorySize

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -121,8 +121,8 @@ async fn test_mtmm_basic() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -156,8 +156,8 @@ async fn test_mtmm_unusual_query_parameters() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -187,8 +187,8 @@ async fn test_mtmm_no_query_parameters() -> Result<(), Error> {
     let request = LambdaEvent::<Value>::new(json!({ "body": point }), Context::default());
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -268,8 +268,8 @@ async fn test_mtmm_many_tags_many_fields() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
@@ -306,8 +306,8 @@ async fn test_mtmm_float() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -341,8 +341,8 @@ async fn test_mtmm_string() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -376,8 +376,8 @@ async fn test_mtmm_bool() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -415,8 +415,8 @@ async fn test_mtmm_max_tag_length() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -491,8 +491,8 @@ async fn test_mtmm_max_field_length() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -570,8 +570,8 @@ async fn test_mtmm_max_unique_field_keys() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -654,8 +654,8 @@ async fn test_mtmm_max_unique_tag_keys() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -733,8 +733,8 @@ async fn test_mtmm_max_table_name_length() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -806,8 +806,8 @@ async fn test_mtmm_nanosecond_precision() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -841,8 +841,8 @@ async fn test_mtmm_microsecond_precision() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -876,8 +876,8 @@ async fn test_mtmm_second_precision() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -915,8 +915,8 @@ async fn test_mtmm_no_precision() -> Result<(), Error> {
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
 
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -942,8 +942,8 @@ async fn test_mtmm_empty_point() -> Result<(), Error> {
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
 
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     Ok(())
 }
@@ -973,8 +973,8 @@ pub async fn test_mtmm_small_timestamp() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -1016,8 +1016,8 @@ async fn test_mtmm_5_measurements() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), table_names_to_delete);
@@ -1059,8 +1059,8 @@ async fn test_mtmm_100_measurements() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), table_names_to_delete);
@@ -1100,8 +1100,8 @@ async fn test_mtmm_5000_batch() -> Result<(), Error> {
     );
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
-    println!("Response: {}: {:?}", response["status"], response["body"]);
-    assert!(response["status"] == 200);
+    println!("Response: {}: {:?}", response["statusCode"], response["body"]);
+    assert!(response["statusCode"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -2,10 +2,9 @@ use anyhow::Error;
 use aws_credential_types::Credentials;
 use aws_sdk_timestreamwrite as timestream_write;
 use aws_types::region::Region;
-use lambda_http::http::StatusCode;
-use lambda_http::{http::Request, IntoResponse};
-use lambda_http::{Body, RequestExt};
+use lambda_runtime::{Context, LambdaEvent};
 use rand::{distributions::uniform::SampleUniform, distributions::Alphanumeric, Rng};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::{env, thread, time};
 
@@ -116,16 +115,80 @@ async fn test_mtmm_basic() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
+
+    let mut cleanup_batch =
+        CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
+    cleanup_batch.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mtmm_unusual_query_parameters() -> Result<(), Error> {
+    // Tests ingesting a single point with a query parameters key with unusual spelling.
+    set_environment_variables();
+    let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
+        .await
+        .expect("Failed to get client");
+
+    let lp_measurement_name = String::from("readings");
+
+    let point = format!(
+        "{},tag1={} field1={}i {}\n",
+        lp_measurement_name,
+        random_string(9),
+        random_number(0, 100001),
+        chrono::offset::Utc::now().timestamp_millis()
+    );
+
+    let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "QUERYtestStrparaMETERS": query_parameters, "body": point }),
+        Context::default(),
+    );
+
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
+
+    let mut cleanup_batch =
+        CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
+    cleanup_batch.cleanup().await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mtmm_no_query_parameters() -> Result<(), Error> {
+    // Tests ingesting a single point without query parameters.
+    set_environment_variables();
+    let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
+        .await
+        .expect("Failed to get client");
+
+    let lp_measurement_name = String::from("readings");
+
+    let point = format!(
+        "{},tag1={} field1={}i {}\n",
+        lp_measurement_name,
+        random_string(9),
+        random_number(0, 100001),
+        chrono::offset::Utc::now().timestamp_millis()
+    );
+
+    let request = LambdaEvent::<Value>::new(json!({ "body": point }), Context::default());
+
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -137,6 +200,8 @@ async fn test_mtmm_basic() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_multiple_timestamps() -> Result<(), Error> {
     // Tests ingesting a single point with two timestamps.
+    // Note, the connector either returns JSON with a 200 status code or an Error. This is so that
+    // the dead letter queue works when the connector is deployed as part of a stack.
     set_environment_variables();
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
@@ -154,16 +219,17 @@ async fn test_mtmm_multiple_timestamps() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() != StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    assert!(response.is_err());
+
+    let mut cleanup_batch =
+        CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
+    cleanup_batch.cleanup().await;
 
     Ok(())
 }
@@ -196,16 +262,14 @@ async fn test_mtmm_many_tags_many_fields() -> Result<(), Error> {
     point.push_str(&format!(" {}\n", chrono::Utc::now().timestamp_millis()));
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
@@ -236,16 +300,14 @@ async fn test_mtmm_float() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -273,16 +335,14 @@ async fn test_mtmm_string() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -310,16 +370,14 @@ async fn test_mtmm_bool() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -351,16 +409,14 @@ async fn test_mtmm_max_tag_length() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -392,16 +448,13 @@ async fn test_mtmm_beyond_max_tag_length() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() != StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    assert!(response.is_err());
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -432,16 +485,14 @@ async fn test_mtmm_max_field_length() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -472,16 +523,13 @@ async fn test_mtmm_beyond_max_field_length() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() != StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    assert!(response.is_err());
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -516,16 +564,14 @@ async fn test_mtmm_max_unique_field_keys() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -560,16 +606,14 @@ async fn test_mtmm_beyond_max_unique_field_keys() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() != StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    println!("Response: {:?}", response);
+    assert!(response.is_err());
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -604,16 +648,14 @@ async fn test_mtmm_max_unique_tag_keys() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -648,16 +690,14 @@ async fn test_mtmm_beyond_max_unique_tag_keys() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() != StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    println!("Response: {:?}", response);
+    assert!(response.is_err());
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -687,16 +727,14 @@ async fn test_mtmm_max_table_name_length() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -706,7 +744,7 @@ async fn test_mtmm_max_table_name_length() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn test_mtmm_beyond_max_table_name_length() {
+async fn test_mtmm_beyond_max_table_name_length() -> Result<(), Error> {
     // Tests ingesting a single point with measurement with length
     // exceeding the maximum number of bytes a Timestream table name can
     // have.
@@ -726,19 +764,19 @@ async fn test_mtmm_beyond_max_table_name_length() {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))
-        .expect("Failed to create request")
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await
-        .expect("Failed to send request to lambda handler")
-        .into_response()
-        .await;
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    assert!(response.is_err());
 
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() != StatusCode::OK);
+    let mut cleanup_batch =
+        CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
+    cleanup_batch.cleanup().await;
+
+    Ok(())
 }
 
 #[tokio::test]
@@ -762,16 +800,14 @@ async fn test_mtmm_nanosecond_precision() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ns".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -799,16 +835,14 @@ async fn test_mtmm_microsecond_precision() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "us".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -836,16 +870,14 @@ async fn test_mtmm_second_precision() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "s".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -876,15 +908,15 @@ async fn test_mtmm_no_precision() -> Result<(), Error> {
             .expect("Failed to create nanosecond timestamp")
     );
 
-    let request = Request::builder().method("POST").body(Body::Text(point))?;
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": "", "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
 
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -903,15 +935,15 @@ async fn test_mtmm_empty_point() -> Result<(), Error> {
 
     let point = String::new();
 
-    let request = Request::builder().method("POST").body(Body::Text(point))?;
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": "", "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
 
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     Ok(())
 }
@@ -935,16 +967,14 @@ pub async fn test_mtmm_small_timestamp() -> Result<(), Error> {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -980,16 +1010,14 @@ async fn test_mtmm_5_measurements() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), table_names_to_delete);
@@ -1025,16 +1053,14 @@ async fn test_mtmm_100_measurements() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), table_names_to_delete);
@@ -1068,16 +1094,14 @@ async fn test_mtmm_5000_batch() -> Result<(), Error> {
     }
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(lp_batch))?
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
 
-    let response = influxdb_timestream_connector::lambda_handler(&client, request)
-        .await?
-        .into_response()
-        .await;
-    println!("Response: {}: {:?}", response.status(), response.body());
-    assert!(response.status() == StatusCode::OK);
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await?;
+    println!("Response: {}: {:?}", response["status"], response["body"]);
+    assert!(response["status"] == 200);
 
     let mut cleanup_batch =
         CleanupBatch::new(client, DATABASE_NAME.to_string(), vec![lp_measurement_name]);
@@ -1115,12 +1139,12 @@ async fn test_mtmm_no_credentials() {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))
-        .expect("Failed to created request")
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let _response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    let _ = influxdb_timestream_connector::lambda_handler(&client, request).await;
 }
 
 #[tokio::test]
@@ -1158,10 +1182,10 @@ async fn test_mtmm_incorrect_credentials() {
     );
 
     let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
-    let request = Request::builder()
-        .body(Body::Text(point))
-        .expect("Failed to created request")
-        .with_query_string_parameters(query_parameters);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
 
-    let _response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    let _ = influxdb_timestream_connector::lambda_handler(&client, request).await;
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -876,9 +876,7 @@ async fn test_mtmm_no_precision() -> Result<(), Error> {
             .expect("Failed to create nanosecond timestamp")
     );
 
-    let request = Request::builder()
-        .method("POST")
-        .body(Body::Text(point))?;
+    let request = Request::builder().method("POST").body(Body::Text(point))?;
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request)
         .await?
@@ -905,9 +903,7 @@ async fn test_mtmm_empty_point() -> Result<(), Error> {
 
     let point = String::new();
 
-    let request = Request::builder()
-        .method("POST")
-        .body(Body::Text(point))?;
+    let request = Request::builder().method("POST").body(Body::Text(point))?;
 
     let response = influxdb_timestream_connector::lambda_handler(&client, request)
         .await?


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

- SAM template `template.yml` added.
    - Asynchronous and synchronous invocation supported.
- Documentation for how the connector can be deployed using the SAM template added.
- `lambda_runtime` crate added.
- `LambdaEvent<serde_json::Value>` used instead of `lambda_http::Request`, in order to support more types of requests, instead of just AWS service integrations.
- Tests added for handling different kinds of `queryParameters` keys in requests.
- DLQ implemented for asynchronous invocation.
- Integration tests changed to check the newly returned `serde_json::Value` struct.

- [x] Unit tests passed.
- [x] Integration tests passed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
