### PR TITLE
Optimize connector

### DIFF
--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
@@ -60,6 +60,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +846,29 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1098,6 +1176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,15 +1327,23 @@ dependencies = [
  "aws-sdk-timestreamwrite",
  "aws-types",
  "chrono",
+ "env_logger",
  "futures",
  "influxdb-line-protocol",
  "lambda_runtime",
+ "log",
  "rand",
  "rayon",
  "serde",
  "serde_json",
  "tokio",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -2281,6 +2373,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
@@ -1337,6 +1337,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1406,8 +1408,6 @@ dependencies = [
  "tokio",
  "tower",
  "tower-service",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1510,6 +1510,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1569,12 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -2291,12 +2307,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
+name = "tracing-log"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "serde",
+ "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -2307,15 +2324,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-serde",
+ "tracing-log",
 ]
 
 [[package]]

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
@@ -669,6 +669,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1247,7 @@ dependencies = [
  "influxdb-line-protocol",
  "lambda_runtime",
  "rand",
+ "rayon",
  "serde",
  "serde_json",
  "tokio",
@@ -1583,6 +1609,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
@@ -813,9 +813,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -838,15 +838,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -855,15 +855,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -872,21 +872,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1218,6 +1218,7 @@ dependencies = [
  "aws-sdk-timestreamwrite",
  "aws-types",
  "chrono",
+ "futures",
  "influxdb-line-protocol",
  "lambda_runtime",
  "rand",

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.lock
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4.38"
 futures = "0.3.31"
 influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "d81f63ddc10e3cf1c28b05e6c1cef03b71da7f8a" }
 rand = "0.5.0"
+rayon = "1.10.0"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.1"
 tokio = { version = "1.39.3", features = ["full"] }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -38,5 +38,3 @@ mag_store_retention_period = "8000"
 mem_store_retention_period = "12"
 local_invocation = "true"
 
-[profile.release]
-debug = true

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -17,8 +17,10 @@ aws-sdk-s3 = "1.46.0"
 aws-sdk-timestreamwrite = "1.39.0"
 aws-types = "1.3.3"
 chrono = "0.4.38"
+env_logger = "0.11.5"
 futures = "0.3.31"
 influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "d81f63ddc10e3cf1c28b05e6c1cef03b71da7f8a" }
+log = "0.4.22"
 rand = "0.5.0"
 rayon = "1.10.0"
 serde = { version = "1.0.208", features = ["derive"] }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -17,6 +17,7 @@ aws-sdk-s3 = "1.46.0"
 aws-sdk-timestreamwrite = "1.39.0"
 aws-types = "1.3.3"
 chrono = "0.4.38"
+futures = "0.3.31"
 influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "d81f63ddc10e3cf1c28b05e6c1cef03b71da7f8a" }
 rand = "0.5.0"
 serde = { version = "1.0.208", features = ["derive"] }
@@ -33,3 +34,6 @@ enable_mag_store_writes = "true"
 mag_store_retention_period = "8000"
 mem_store_retention_period = "12"
 local_invocation = "true"
+
+[profile.release]
+debug = true

--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies.lambda_runtime]
 version = "0.13.0"
 default-features = false
-features = ["anyhow", "tracing"]
+features = ["anyhow"]
 
 [dependencies]
 anyhow = "1.0.86"
@@ -26,6 +26,8 @@ rayon = "1.10.0"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.1"
 tokio = { version = "1.39.3", features = ["full"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [package.metadata.lambda.env]
 region = "us-east-1"

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -508,9 +508,9 @@ The following command will run the connector with its logging level set to `TRAC
 
 ```shell
 cargo lambda watch \
-    --env-var RUST_LOG=trace 2>&1 | \
+    --env-var RUST_LOG=TRACE 2>&1 | \
     tee /dev/tty | \
-    grep --line-buffered 'TRACE influxdb_timestream_connector' > function_duration.log
+    grep --line-buffered "TRACE.*influxdb_timestream_connector" > function_duration.log
 ```
 
 ### Enabling Trace Logging for CloudFormation Deployment

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -556,3 +556,22 @@ In order to ingest to Timestream for LiveAnalytics, every line protocol point mu
 
 The connector expects query string parameters to be included as `queryParameters` or `queryStringParameters` in requests.
 
+### Stack Cost
+
+The costs incurred by the connector when deployed as a CloudFormation stack may be expensive compared to the costs of ingesting to Timestream for LiveAnalytics (28%-46% of ingestion costs during product testing).
+
+#### Solution
+
+A number of details impact stack costs:
+
+- The number of requests to the REST API Gateway.
+- The size of requests sent to the REST API Gateway.
+- The Lambda memory size.
+- The number of line protocol points in a request, which directly impact Lambda execution time.
+- With multi-table multi measure schema, the number of unique measurement names, which directly impact Lambda execution time by causing tables to be created or checked.
+
+The following approaches help reduce stack costs:
+
+- The REST API Gateway incurs the highest costs for the stack. Reduce REST API Gateway costs by including as many line protocol points in a request as possible. 500-20,000 line protocol points in each request is ideal. The Lambda memory size, Lambda timeout, REST API Gateway timeout, and client timeout may have to be increased in order to accommodate larger requests.
+- If possible, create the necessary tables in advance, to reduce the time the connector will take to create tables. The connector adds a one second delay for table or database creation in order to avoid throttling.
+- Reduce the amount of memory the connector uses as a Lambda function. The default, and smallest possible value, is 128 MB.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -546,16 +546,6 @@ When using multi-table multi measure schema and ingesting line protocol data in 
 1. Consider creating the tables before ingestion, using each unique measurement in the line protocol data as the table names.
 2. Re-ingest failed requests. Failed requests will be stored in the Lambda's dead letter queue.
 
-## Caveats
-
-### Line Protocol Tag Requirement
-
-In order to ingest to Timestream for LiveAnalytics, every line protocol point must include at least one tag.
-
-### Query String Parameters
-
-The connector expects query string parameters to be included as `queryParameters` or `queryStringParameters` in requests.
-
 ### Stack Cost
 
 The following is an overview of how the costs are calculated for each deployed resource in the CloudFormation stack, at the time of writing (Oct. 21, 2024). These calculations are based on the calculations used by the [AWS pricing calculator](https://calculator.aws/#/). Refer to the AWS pricing calculator for a more accurate estimate:
@@ -577,7 +567,17 @@ The following is an overview of how the costs are calculated for each deployed r
 
 The following are some approaches that can reduce stack costs:
 
-- The REST API Gateway incurs the highest costs for the stack. Reduce REST API Gateway costs by including as many line protocol points in a request as possible. 500-20,000 line protocol points in each request is ideal. The Lambda memory size, Lambda timeout, REST API Gateway timeout, and client timeout may have to be increased in order to accommodate larger requests.
+- The REST API Gateway incurs the highest costs for the stack. Reduce REST API Gateway costs by including as many line protocol points in a request as possible. 5,000-20,000 line protocol points in each request is ideal. The Lambda memory size, Lambda timeout, REST API Gateway timeout, and client timeout may have to be increased in order to accommodate larger requests.
     - NOTE: if requests contain only a single line protocol point, the ratio of REST API Gateway requests to ingested records would be 1:1 and costs would be much higher than including multiple line protocol points in each request.
 - If possible, create the necessary tables in advance, to reduce the time the connector will take to create tables. The connector adds a one second delay for table or database creation in order to avoid throttling.
 - Reduce the amount of memory the connector uses as a Lambda function. The default, and smallest possible value, is 128 MB.
+
+## Caveats
+
+### Line Protocol Tag Requirement
+
+In order to ingest to Timestream for LiveAnalytics, every line protocol point must include at least one tag.
+
+### Query String Parameters
+
+The connector expects query string parameters to be included as `queryParameters` or `queryStringParameters` in requests.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -71,6 +71,7 @@ The following parameters are available when deploying the connector as part of a
 | `RestApiGatewayName` | The name to use for the REST API Gateway. | `InfluxDB-Timestream-Connector-REST-API-Gateway` |
 | `RestApiGatewayStageName` | The name to use for the REST API Gateway stage. | `dev` |
 | `RestApiGatewayTimeoutInMillis` | The maximum number of milliseconds a REST API Gateway event will wait before timing out. | `30000` |
+| `RustLog` | The log level to use for the Lambda function. Typical values are error, warn, info, debug, trace, and off. Use trace in order to log the execution time of each function. | `INFO` |
 | `WriteThrottlingBurstLimit` | The number of burst requests per second that the REST API Gateway permits. | `1200` |
 
 ##### SAM Deployment Steps
@@ -494,6 +495,27 @@ Due to the connector translating line protocol to Timestream records, line proto
 ### Database and Table Creation Delay
 
 There is a delay of one second added before deleting or creating a table or database. This is because of Timestream for LiveAnalytics' "Throttle rate for CRUD APIs" [quota](https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.default) of one table/database deletion/creation per second.
+
+## Logging
+
+Logging levels for the connector can be configured using the `RUST_LOG` [Rust environment variable](https://docs.rs/env_logger/latest/env_logger/#enabling-logging). By default, the logging level the connector uses is `INFO`.
+
+The `TRACE` logging level displays execution time for each function in the connector.
+
+### Enabling Trace Logging for Local Deployment
+
+The following command will run the connector with its logging level set to `TRACE` and output function durations to a file:
+
+```shell
+cargo lambda watch \
+    --env-var RUST_LOG=trace 2>&1 | \
+    tee /dev/tty | \
+    grep --line-buffered 'TRACE influxdb_timestream_connector' > function_duration.log
+```
+
+### Enabling Trace Logging for CloudFormation Deployment
+
+The parameter `RustLog` allows configuration of the `RUST_LOG` environment variable for the Lambda function.
 
 ## Troubleshooting
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -571,6 +571,7 @@ The following are some approaches that can reduce stack costs:
     - NOTE: if requests contain only a single line protocol point, the ratio of REST API Gateway requests to ingested records would be 1:1 and costs would be much higher than including multiple line protocol points in each request.
 - If possible, create the necessary tables in advance, to reduce the time the connector will take to create tables. The connector adds a one second delay for table or database creation in order to avoid throttling.
 - Reduce the amount of memory the connector uses as a Lambda function. The default, and smallest possible value, is 128 MB.
+- Set the `EnableDatabaseCreation` or `EnableTableCreation` parameter to `false` to skip checks for existing databases or tables, if unnecessary.
 
 ## Caveats
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -78,7 +78,7 @@ async fn handle_multi_table_ingestion(
     }
 
     // Use a semaphore to limit the maximum number of threads used to process batches in parallel
-    let semaphore = Arc::new(Semaphore::new(NUM_BATCH_THREADS));
+    let ingestion_semaphore = Arc::new(Semaphore::new(NUM_BATCH_THREADS));
     let mut batch_ingestion_futures = FuturesUnordered::new();
 
     // Track total time taken to check existence of tables and ingest records
@@ -86,7 +86,7 @@ async fn handle_multi_table_ingestion(
 
     // Ingest records for each table, in parallel
     for (table_name, records) in records {
-        let permit = semaphore
+        let permit = ingestion_semaphore
             .clone()
             .acquire_owned()
             .await

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -199,8 +199,6 @@ pub async fn lambda_handler(
 
     let (event, _context) = event.into_parts();
 
-    info!("Size of event: {:?}", event.to_string().as_bytes().len());
-
     let precision = match get_precision(&event) {
         Some("ms") => timestream_write::types::TimeUnit::Milliseconds,
         Some("us") => timestream_write::types::TimeUnit::Microseconds,

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -6,8 +6,8 @@ use line_protocol_parser::*;
 use records_builder::*;
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::{str, thread, time};
 use std::sync::Arc;
+use std::{str, thread, time};
 use timestream_utils::*;
 use tokio::task;
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -4,7 +4,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use lambda_runtime::LambdaEvent;
 use line_protocol_parser::*;
-use log::trace;
+use log::{info, trace};
 use records_builder::*;
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -103,7 +103,7 @@ async fn handle_multi_table_ingestion(
                             ));
                         }
                     }
-                    Err(error) => println!("error checking table exists: {:?}", error),
+                    Err(error) => info!("error checking table exists: {:?}", error),
                 }
             }
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/line_protocol_parser.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/line_protocol_parser.rs
@@ -1,14 +1,10 @@
-use std::time::Instant;
-
 use crate::metric::{self, Metric};
 use anyhow::{anyhow, Error};
 use influxdb_line_protocol::{self, parse_lines, ParsedLine};
-use log::trace;
 
+#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 pub fn parse_line_protocol(line_protocol: &str) -> Result<Vec<Metric>, Error> {
     // Parses a string of line protocol to a vector of Metric structs,
-
-    let function_start = Instant::now();
 
     let parsed_lines = parse_lines(line_protocol);
     let mut output_metrics: Vec<Metric> = Vec::new();
@@ -24,17 +20,13 @@ pub fn parse_line_protocol(line_protocol: &str) -> Result<Vec<Metric>, Error> {
             }
         }
     }
-    trace!(
-        "parse_line_protocol duration: {:?}",
-        function_start.elapsed()
-    );
+
     Ok(output_metrics)
 }
 
+#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 pub fn parsed_line_to_metric(parsed_line: ParsedLine) -> Result<Metric, Error> {
     // Converts an influxdb_line_protocol ParsedLine struct to a Metric struct.
-
-    let function_start = Instant::now();
 
     let mut new_tags: Vec<(String, String)> = Vec::new();
     if let Some(tag_set) = parsed_line.series.tag_set.as_ref() {
@@ -75,19 +67,12 @@ pub fn parsed_line_to_metric(parsed_line: ParsedLine) -> Result<Metric, Error> {
     }
 
     match parsed_line.timestamp {
-        Some(timestamp) => {
-            let result = Ok(Metric::new(
-                parsed_line.series.measurement.to_string(),
-                Some(new_tags),
-                new_fields,
-                timestamp,
-            ));
-            trace!(
-                "parsed_line_to_metric duration: {:?}",
-                function_start.elapsed()
-            );
-            result
-        }
+        Some(timestamp) => Ok(Metric::new(
+            parsed_line.series.measurement.to_string(),
+            Some(new_tags),
+            new_fields,
+            timestamp,
+        )),
         None => Err(anyhow!("Failed to parse timestamp")),
     }
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Error> {
         .with_target(true)
         .with_thread_names(true)
         .with_level(true)
-        .pretty()
+        .compact()
         .init();
 
     // Set global maximum rayon threads

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
@@ -1,3 +1,4 @@
+use env_logger::Env;
 use influxdb_timestream_connector::{
     lambda_handler, records_builder::validate_env_variables, timestream_utils::get_connection,
 };
@@ -7,7 +8,8 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    env_logger::init();
+    let env = Env::default().filter_or("RUST_LOG", "INFO");
+    env_logger::Builder::from_env(env).init();
     validate_env_variables()?;
     let region = std::env::var("region")?;
     let timestream_client = get_connection(&region).await?;

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
@@ -3,12 +3,14 @@ use influxdb_timestream_connector::{
 };
 use lambda_runtime::{run, service_fn, tracing, Error, LambdaEvent};
 use serde_json::Value;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     validate_env_variables()?;
     let region = std::env::var("region")?;
     let timestream_client = get_connection(&region).await?;
+    let timestream_client = Arc::new(timestream_client);
     tracing::init_default_subscriber();
     run(service_fn(|event: LambdaEvent<Value>| {
         lambda_handler(&timestream_client, event)

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    env_logger::init();
     validate_env_variables()?;
     let region = std::env::var("region")?;
     let timestream_client = get_connection(&region).await?;

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_table_multi_measure_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_table_multi_measure_builder.rs
@@ -2,7 +2,8 @@ use super::{validate_env_variables, BuildRecords};
 use crate::metric::{FieldValue, Metric};
 use anyhow::{anyhow, Error, Result};
 use aws_sdk_timestreamwrite as timestream_write;
-use std::collections::HashMap;
+use log::trace;
+use std::{collections::HashMap, time::Instant};
 
 pub struct MultiTableMultiMeasureBuilder {
     pub measure_name: String,
@@ -16,14 +17,19 @@ impl BuildRecords for MultiTableMultiMeasureBuilder {
         metrics: &[Metric],
         precision: &timestream_write::types::TimeUnit,
     ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
+        let function_start = Instant::now();
         validate_env_variables()?;
         validate_multi_measure_env_variables()?;
-        build_multi_measure_records(metrics, &self.measure_name, precision)
+        let result = build_multi_measure_records(metrics, &self.measure_name, precision);
+        trace!("build_records duration: {:?}", function_start.elapsed());
+        result
     }
 }
 
 fn validate_multi_measure_env_variables() -> Result<(), Error> {
     // Validate environment variables for multi-measure schema types
+
+    let function_start = Instant::now();
 
     if std::env::var("measure_name_for_multi_measure_records").is_err() {
         return Err(anyhow!(
@@ -31,6 +37,10 @@ fn validate_multi_measure_env_variables() -> Result<(), Error> {
         ));
     }
 
+    trace!(
+        "validate_multi_measure_env_variables duration: {:?}",
+        function_start.elapsed()
+    );
     Ok(())
 }
 
@@ -40,6 +50,8 @@ fn build_multi_measure_records(
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
     // Builds multi-measure multi-table records hashmap
+
+    let function_start = Instant::now();
 
     let mut multi_table_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
         HashMap::new();
@@ -53,6 +65,10 @@ fn build_multi_measure_records(
         }
     }
 
+    trace!(
+        "build_multi_measure_records duration: {:?}",
+        function_start.elapsed()
+    );
     Ok(multi_table_batch)
 }
 
@@ -62,6 +78,8 @@ pub fn metric_to_timestream_record(
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<timestream_write::types::Record, Error> {
     // Converts the metric struct to a timestream multi-measure record
+
+    let function_start = Instant::now();
 
     let mut dimensions: Vec<timestream_write::types::Dimension> = Vec::new();
     for tag in metric.tags().iter().flatten() {
@@ -96,6 +114,10 @@ pub fn metric_to_timestream_record(
         .set_dimensions(Some(dimensions))
         .build();
 
+    trace!(
+        "metric_to_timestream_record duration: {:?}",
+        function_start.elapsed()
+    );
     Ok(new_record)
 }
 
@@ -104,11 +126,17 @@ pub fn get_timestream_measure_type(
 ) -> Result<timestream_write::types::MeasureValueType, Error> {
     // Converts a metric struct type to a timestream measure value type
 
-    match field_value {
+    let function_start = Instant::now();
+    let val = match field_value {
         FieldValue::Boolean(_) => Ok(timestream_write::types::MeasureValueType::Boolean),
         FieldValue::I64(_) => Ok(timestream_write::types::MeasureValueType::Bigint),
         FieldValue::U64(_) => Ok(timestream_write::types::MeasureValueType::Bigint),
         FieldValue::F64(_) => Ok(timestream_write::types::MeasureValueType::Double),
         FieldValue::String(_) => Ok(timestream_write::types::MeasureValueType::Varchar),
-    }
+    };
+    trace!(
+        "get_timestream_measure_type duration: {:?}",
+        function_start.elapsed()
+    );
+    val
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
@@ -3,6 +3,7 @@ use anyhow::{anyhow, Error, Result};
 use aws_sdk_timestreamwrite as timestream_write;
 use aws_types::region::Region;
 use futures::future::join_all;
+use rayon::prelude::*;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::task;
@@ -155,7 +156,7 @@ pub async fn ingest_records(
     const MAX_TIMESTREAM_BATCH_SIZE: usize = 100;
 
     let records_chunked: Vec<Vec<timestream_write::types::Record>> = records
-        .chunks(MAX_TIMESTREAM_BATCH_SIZE)
+        .par_chunks(MAX_TIMESTREAM_BATCH_SIZE)
         .map(|sub_records| sub_records.to_vec())
         .collect();
     let mut tasks = Vec::new();

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
@@ -173,7 +173,7 @@ pub async fn database_exists(
 
 pub async fn ingest_records(
     client: Arc<timestream_write::Client>,
-    database_name: String,
+    database_name: Arc<String>,
     table_name: String,
     records: Vec<timestream_write::types::Record>,
 ) -> Result<(), Error> {

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
@@ -4,7 +4,7 @@ use aws_sdk_timestreamwrite as timestream_write;
 use aws_types::region::Region;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use log::trace;
+use log::{info, trace};
 use rayon::prelude::*;
 use std::sync::Arc;
 use std::time::Instant;
@@ -27,7 +27,7 @@ pub async fn get_connection(
         .expect("Failed to get the write client connection with Timestream");
 
     tokio::task::spawn(reload.reload_task());
-    println!("Initialized connection to Timestream in region {}", region);
+    info!("Initialized connection to Timestream in region {}", region);
 
     trace!("get_connection duration: {:?}", function_start.elapsed());
     Ok(client)
@@ -41,7 +41,7 @@ pub async fn create_database(
 
     let function_start = Instant::now();
 
-    println!("Creating new database {}", database_name);
+    info!("Creating new database {}", database_name);
     client
         .create_database()
         .set_database_name(Some(database_name.to_owned()))
@@ -62,7 +62,7 @@ pub async fn create_table(
 
     let function_start = Instant::now();
 
-    println!(
+    info!(
         "Creating new table {} for database {}",
         table_name, database_name
     );
@@ -211,7 +211,7 @@ pub async fn ingest_records(
         }
     }
 
-    println!(
+    info!(
         "{} records ingested total for table {} in database {}",
         records_ingested, table_name, database_name
     );
@@ -236,7 +236,7 @@ pub async fn ingest_record_batch(
     {
         Ok(_) => {}
         Err(error) => {
-            println!("SdkError: {:?}", error.raw_response().unwrap());
+            info!("SdkError: {:?}", error.raw_response().unwrap());
             return Err(anyhow!(error));
         }
     };

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
@@ -174,12 +174,12 @@ pub async fn ingest_records(
         .collect();
 
     // Use a semaphore to limit the maximum number of threads used to ingest chunks in parallel
-    let semaphore = Arc::new(Semaphore::new(NUM_TIMESTREAM_INGEST_THREADS));
+    let ingestion_semaphore = Arc::new(Semaphore::new(NUM_TIMESTREAM_INGEST_THREADS));
     let mut ingestion_futures = FuturesUnordered::new();
 
     // Ingest chunks in parallel
     for chunk in records_chunked {
-        let permit = semaphore
+        let permit = ingestion_semaphore
             .clone()
             .acquire_owned()
             .await

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -94,6 +94,10 @@ Parameters:
     MinValue: 2
     Default: 30000
     Description: The maximum amount of time in milliseconds an API Gateway event will wait before timing out.
+  RustLog:
+    Type: String
+    Default: 'INFO'
+    Description: The log level to use for the Lambda function. Typical values are error, warn, info, debug, trace, and off. Use trace in order to log the execution time of each function. Defaults to INFO.
   LambdaTimeoutInSeconds:
     Type: Number
     MinValue: 3
@@ -544,6 +548,7 @@ Resources:
           enforce_custom_partition_key: !If [EnforceCustomPartitionKeyProvided, !Ref EnforceCustomPartitionKey, !Ref "AWS::NoValue"]
           mag_store_retention_period: !Ref MagStoreRetentionPeriod
           mem_store_retention_period: !Ref MemStoreRetentionPeriod
+          RUST_LOG: !Ref RustLog
       PackageType: Zip
       Timeout: !Ref LambdaTimeoutInSeconds
       MemorySize: !Ref LambdaMemorySize

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -7,6 +7,7 @@ use rand::{distributions::uniform::SampleUniform, distributions::Alphanumeric, R
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::{env, thread, time};
+use std::sync::Arc;
 
 static DATABASE_NAME: &str = "influxdb_timestream_connector_integ_db";
 static REGION: &str = "us-west-2";
@@ -99,6 +100,7 @@ async fn test_mtmm_basic() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -136,6 +138,7 @@ async fn test_mtmm_create_database() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -185,6 +188,7 @@ async fn test_mtmm_unusual_query_parameters() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -220,6 +224,7 @@ async fn test_mtmm_no_query_parameters() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -253,6 +258,7 @@ async fn test_mtmm_multiple_timestamps() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -287,6 +293,7 @@ async fn test_mtmm_many_tags_many_fields() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -334,6 +341,7 @@ async fn test_mtmm_float() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -369,6 +377,7 @@ async fn test_mtmm_string() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -404,6 +413,7 @@ async fn test_mtmm_bool() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -442,6 +452,7 @@ async fn test_mtmm_max_tag_length() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -481,6 +492,7 @@ async fn test_mtmm_beyond_max_tag_length() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -517,6 +529,7 @@ async fn test_mtmm_max_field_length() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -555,6 +568,7 @@ async fn test_mtmm_beyond_max_field_length() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -591,6 +605,7 @@ async fn test_mtmm_max_unique_field_keys() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -633,6 +648,7 @@ async fn test_mtmm_beyond_max_unique_field_keys() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -674,6 +690,7 @@ async fn test_mtmm_max_unique_tag_keys() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -716,6 +733,7 @@ async fn test_mtmm_beyond_max_unique_tag_keys() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -757,6 +775,7 @@ async fn test_mtmm_max_table_name_length() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = random_string(MAX_TIMESTREAM_TABLE_NAME_LENGTH);
 
@@ -794,6 +813,7 @@ async fn test_mtmm_beyond_max_table_name_length() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = random_string(MAX_TIMESTREAM_TABLE_NAME_LENGTH + 1);
 
@@ -827,6 +847,7 @@ async fn test_mtmm_nanosecond_precision() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -864,6 +885,7 @@ async fn test_mtmm_microsecond_precision() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -899,6 +921,7 @@ async fn test_mtmm_second_precision() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -934,6 +957,7 @@ async fn test_mtmm_no_precision() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -972,6 +996,7 @@ async fn test_mtmm_empty_point() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let point = String::new();
 
@@ -995,6 +1020,7 @@ pub async fn test_mtmm_small_timestamp() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1030,6 +1056,7 @@ async fn test_mtmm_5_measurements() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let mut table_names_to_delete = Vec::<String>::new();
     let lp_measurement_name = String::from("readings");
@@ -1073,6 +1100,7 @@ async fn test_mtmm_100_measurements() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let mut table_names_to_delete = Vec::<String>::new();
 
@@ -1118,6 +1146,7 @@ async fn test_mtmm_5000_batch() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
     let mut lp_batch = String::new();
@@ -1166,6 +1195,7 @@ async fn test_mtmm_no_credentials() {
         .with_endpoint_discovery_enabled()
         .await
         .expect("Failed to get the write client connection with Timestream");
+    let client = Arc::new(client);
     tokio::task::spawn(reload.reload_task());
 
     let lp_measurement_name = String::from("readings");
@@ -1209,6 +1239,7 @@ async fn test_mtmm_incorrect_credentials() {
         .with_endpoint_discovery_enabled()
         .await
         .expect("Failed to get the write client connection with Timestream");
+    let client = Arc::new(client);
     tokio::task::spawn(reload.reload_task());
 
     let lp_measurement_name = String::from("readings");
@@ -1241,6 +1272,7 @@ async fn test_mtmm_custom_dimension_partition_key_optional_enforcement() -> Resu
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1281,6 +1313,7 @@ async fn test_mtmm_custom_dimension_partition_key_required_enforcement_accepted(
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1321,6 +1354,7 @@ async fn test_mtmm_custom_dimension_partition_key_required_enforcement_rejected(
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1359,6 +1393,7 @@ async fn test_mtmm_custom_dimension_partition_key_no_dimension() -> Result<(), E
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1397,6 +1432,7 @@ async fn test_mtmm_custom_dimension_partition_key_no_enforcement() -> Result<(),
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1435,6 +1471,7 @@ async fn test_mtmm_custom_measure_partition_key() -> Result<(), Error> {
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1474,6 +1511,7 @@ async fn test_mtmm_custom_measure_partition_key_with_dimension() -> Result<(), E
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 
@@ -1514,6 +1552,7 @@ async fn test_mtmm_custom_measure_partition_key_with_enforcement() -> Result<(),
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
+    let client = Arc::new(client);
 
     let lp_measurement_name = String::from("readings");
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -6,8 +6,8 @@ use lambda_runtime::{Context, LambdaEvent};
 use rand::{distributions::uniform::SampleUniform, distributions::Alphanumeric, Rng};
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use std::{env, thread, time};
 use std::sync::Arc;
+use std::{env, thread, time};
 
 static DATABASE_NAME: &str = "influxdb_timestream_connector_integ_db";
 static REGION: &str = "us-west-2";

--- a/integrations/influxdb_connector/sample-influxdb-clients/go/line-protocol-client-demo.go
+++ b/integrations/influxdb_connector/sample-influxdb-clients/go/line-protocol-client-demo.go
@@ -35,7 +35,7 @@ var(
 func main() {
     flag.StringVar(&region, "region", "us-east-1", "AWS region for InfluxDB Timestream Connector")
     flag.StringVar(&service, "service", "lambda", "Service value for SigV4 header")
-    flag.StringVar(&endpoint, "endpoint", "http://127.0.0.1:9000", "Endpoint for InfluxDB Timestream Connector")
+    flag.StringVar(&endpoint, "endpoint", "http://localhost:9000", "Endpoint for InfluxDB Timestream Connector")
     flag.StringVar(&dataset, "dataset", "../data/bird-migration.line", "Line protocol dataset being ingested")
     flag.StringVar(&precision, "precision", "ns", "Precision for line protocol: nanoseconds=ns, milliseconds=ms, microseconds=us, seconds=s")
     flag.Parse()


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*
- Ingestion to multiple tables done in parallel.
- Ingestion of 100 records to a single table done in parallel.
- Chunking of records into batches of 100 done in parallel.
- Limit on maximum possible number of threads added.
- Print statement for each 100 records removed.
- Logging option added to SAM template.
- All `println!` calls changed to `info!`.
- Default logging level for the connector changed to `INFO`.
- Trace statements that measure the execution time of each function added.
- Instructions added to README for how to configure logging levels.
- Database and tables are no longer checked if their corresponding environment variables for creation are not set.
- The checking of whether tables exist has been moved within the asynchronous code block used to ingest records to a table. This checking is now done in parallel and the hashmap is looped through once, instead of twice.
- Instructions added to README for how to reduce stack costs.

- [x] Integration tests passed.
- [x] Unit tests passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
