### PR TITLE
Add Single Table Mapping for InfluxDB Timestream Connector

### DIFF
--- a/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/Cargo.toml
@@ -32,6 +32,8 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 [package.metadata.lambda.env]
 region = "us-east-1"
 database_name = "influxdb-line-protocol"
+table_mapping = "single-table"
+single_table_name = "influxdb-measures"
 measure_name_for_multi_measure_records = "influxdb-measure"
 enable_database_creation = "true"
 enable_table_creation = "true"
@@ -39,4 +41,3 @@ enable_mag_store_writes = "true"
 mag_store_retention_period = "8000"
 mem_store_retention_period = "12"
 local_invocation = "true"
-

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -25,7 +25,7 @@ The following table shows how the connector maps line protocol elements to Times
 
 Single table mapping ingests all line protocol points ingested through the InfluxDB Timestream Connector to the table defined with the `single_table_name` environment variable. The `measure_name` in each Timestream record is derived from the line protocol measurement.
 
-The following example shows the translation of a two line protocol points into a Timestream for LiveAnalytics table, using a Timestamp with second precision and a `single_table_nam` Lambda environment variable configured to `influxdb-measures`:
+The following example shows the translation of two line protocol points into a Timestream for LiveAnalytics table, using Timestamps with second precision and a `single_table_name` Lambda environment variable configured to `influxdb-measures`:
 
 #### Line Protocol Points
 
@@ -39,7 +39,7 @@ weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480
 | host     | region  | measure_name     | time                          | value | average | location   | season | temperature | humidity |
 |----------|---------|------------------|-------------------------------|-------|---------|------------|--------|-------------|----------|
 | server01 | us-west | cpu_load_short   | 2024-08-30 23:07:54.000000000 | 0.64  | 1.24    |            |        |             |          |
-|          |         | weather          | 2024-01-22 26:07:33.000000000 | 0.64  | 1.24    | us-midwest | summer | 82.0        | 71.0     |
+|          |         | weather          | 2024-01-22 26:07:33.000000000 |       |         | us-midwest | summer | 82.0        | 71.0     |
 
 
 ### Multi-Table Multi-Measure
@@ -55,7 +55,7 @@ The following table shows how the connector maps line protocol elements to Times
 
 A Timestream record's `measure_name` field is not derived from any element of ingested line protocol. Due to the multi-measure record translation, the connector sets the `measure_name` for each multi-measure record to the value of a Lambda environment variable. When [deployed as part of a CloudFormation stack](#aws-cloudformation-deployment), this can be customized by overriding the `MeasureNameForMultiMeasureRecords` parameter. When [deployed locally](#local-deployment), this can be customized by setting the `measure_name_for_multi_measure_records` environment variable.
 
-The following example shows the translation of a two line protocol point into two Timestream for LiveAnalytics tables, using a Timestamp with second precision and a Lambda environment variable configured to `influxdb-measure`:
+The following example shows the translation of two line protocol points into two Timestream for LiveAnalytics tables, using Timestamps with second precision and a Lambda environment variable configured to `influxdb-measure`:
 
 #### Line Protocol Points
 
@@ -109,8 +109,8 @@ The following parameters are available when deploying the connector as part of a
 | `RestApiGatewayStageName` | The name to use for the REST API Gateway stage. | `dev` |
 | `RestApiGatewayTimeoutInMillis` | The maximum number of milliseconds a REST API Gateway event will wait before timing out. | `30000` |
 | `RustLog` | The log level to use for the Lambda function. Typical values are error, warn, info, debug, trace, and off. Use trace in order to log the execution time of each function. | `INFO` |
-| `SingleTableName` | Determines the table name for ingestionw hen table mapping is type single-table. | `influxdb-measures` |
-| `TableMapping` | Determines wether to ingest all records to a single table or to multiple tables. | `single-table` |
+| `SingleTableName` | Determines the table name for ingestion when table mapping is type single-table. | `influxdb-measures` |
+| `TableMapping` | Determines whether to ingest all records to a single table or to multiple tables. | `single-table` |
 | `WriteThrottlingBurstLimit` | The number of burst requests per second that the REST API Gateway permits. | `1200` |
 
 ##### SAM Deployment Steps

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -27,7 +27,7 @@ Single table mapping ingests all line protocol points ingested through the Influ
 
 The following example shows the translation of a two line protocol points into a Timestream for LiveAnalytics table, using a Timestamp with second precision and a `single_table_nam` Lambda environment variable configured to `influxdb-measures`:
 
-#### Line Protocol Point
+#### Line Protocol Points
 
 ```
 cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274
@@ -57,7 +57,7 @@ A Timestream record's `measure_name` field is not derived from any element of in
 
 The following example shows the translation of a two line protocol point into two Timestream for LiveAnalytics tables, using a Timestamp with second precision and a Lambda environment variable configured to `influxdb-measure`:
 
-#### Line Protocol Point
+#### Line Protocol Points
 
 ```
 cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -72,8 +72,9 @@ The following parameters are available when deploying the connector as part of a
 | `RestApiGatewayStageName` | The name to use for the REST API Gateway stage. | `dev` |
 | `RestApiGatewayTimeoutInMillis` | The maximum number of milliseconds a REST API Gateway event will wait before timing out. | `30000` |
 | `RustLog` | The log level to use for the Lambda function. Typical values are error, warn, info, debug, trace, and off. Use trace in order to log the execution time of each function. | `INFO` |
-| `WriteThrottlingBurstLimit` | The number of burst requests per second that the REST API Gateway permits. | `1200` |
+| `SingleTableName` | Determines the table name for ingestionw hen table mapping is type single-table. | `influxdb-measures` |
 | `TableMapping` | Determines wether to ingest all records to a single table or to multiple tables. | `single-table` |
+| `WriteThrottlingBurstLimit` | The number of burst requests per second that the REST API Gateway permits. | `1200` |
 
 ##### SAM Deployment Steps
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -10,7 +10,37 @@ The following diagram shows a high-level overview of the connector's architectur
 
 <img src="./docs/img/influxdb_timestream_connector_lambda_function_arch.png" width=700/>
 
-## Table Schema
+## Table Mapping
+
+### Single-Table Multi-Measure
+
+The following table shows how the connector maps line protocol elements to Timestream for LiveAnalytics record attributes when table mapping is set to single table.
+
+| Line Protocol Element | Timestream Record Attribute |
+|-----------------------|---------------------------|
+| Timestamp             | Time                      |
+| Tags                  | Dimensions                |
+| Fields                | Measures                  |
+| Measurements          | Measure names              |
+
+Single table mapping ingests all line protocol points ingested through the InfluxDB Timestream Connector to the table defined with the `single_table_name` environment variable. The `measure_name` in each Timestream record is derived from the line protocol measurement.
+
+The following example shows the translation of a two line protocol points into a Timestream for LiveAnalytics table, using a Timestamp with second precision and a `single_table_nam` Lambda environment variable configured to `influxdb-measures`:
+
+#### Line Protocol Point
+
+```
+cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274
+weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480990
+```
+
+#### Resulting influxdb-measures Timestream for LiveAnalytics Table
+
+| host     | region  | measure_name     | time                          | value | average | location   | season | temperature | humidity |
+|----------|---------|------------------|-------------------------------|-------|---------|------------|--------|-------------|----------|
+| server01 | us-west | cpu_load_short   | 2024-08-30 23:07:54.000000000 | 0.64  | 1.24    |            |        |             |          |
+|          |         | weather          | 2024-01-22 26:07:33.000000000 | 0.64  | 1.24    | us-midwest | summer | 82.0        | 71.0     |
+
 
 ### Multi-Table Multi-Measure
 
@@ -25,12 +55,13 @@ The following table shows how the connector maps line protocol elements to Times
 
 A Timestream record's `measure_name` field is not derived from any element of ingested line protocol. Due to the multi-measure record translation, the connector sets the `measure_name` for each multi-measure record to the value of a Lambda environment variable. When [deployed as part of a CloudFormation stack](#aws-cloudformation-deployment), this can be customized by overriding the `MeasureNameForMultiMeasureRecords` parameter. When [deployed locally](#local-deployment), this can be customized by setting the `measure_name_for_multi_measure_records` environment variable.
 
-The following example shows the translation of a single line protocol point into a Timestream for LiveAnalytics table, using a Timestamp with second precision and a Lambda environment variable configured to `influxdb-measure`:
+The following example shows the translation of a two line protocol point into two Timestream for LiveAnalytics tables, using a Timestamp with second precision and a Lambda environment variable configured to `influxdb-measure`:
 
 #### Line Protocol Point
 
 ```
 cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274
+weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480990
 ```
 
 #### Resulting cpu_load_short Timestream for LiveAnalytics Table
@@ -38,6 +69,12 @@ cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274
 | host     | region  | measure_name     | time                          | value | average |
 |----------|---------|------------------|-------------------------------|-------|---------|
 | server01 | us-west | influxdb-measure | 2024-08-30 23:07:54.000000000 | 0.64  | 1.24    |
+
+#### Resulting weather Timestream for LiveAnalytics Table
+
+| location   | season  | measure_name     | time                          | temperature | humidity |
+|------------|---------|------------------|-------------------------------|-------------|----------|
+| us-midwest | summer  | influxdb-measure | 2024-01-22 26:0733.000000000 | 82.0        | 71.0     |
 
 ## Deployment Options
 
@@ -145,6 +182,8 @@ The connector can be run locally using [Cargo Lambda](https://www.cargo-lambda.i
     - `region` string: the AWS region to use. Defaults to `us-east-1`.
     - `database_name` string: the Timestream for LiveAnalytics database name to use. Defaults to `influxdb-line-protocol`.
     - `measure_name_for_multi_measure_records` string: the value to use in records as the measure name. Defaults to `influxdb-measure`.
+    - `table_mapping` string: determines whether to ingest all data to a single table or multiple tables.
+    - `single_table_name` string: when table mapping is set to `single-table`, this value determines the table name.
     - `enable_database_creation` bool: whether to create a database if the `database_name` database does not already exist in Timestream for LiveAnalytics. Defaults to `true`.
     - `enable_table_creation` bool: whether to create new tables if they don't already exist. Defaults to `true`.
         - `enable_mag_store_writes` bool: if `enable_table_creation` is `true`, whether to enable mag store writes. Defaults to `true`.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -36,10 +36,10 @@ weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480
 
 #### Resulting influxdb-measures Timestream for LiveAnalytics Table
 
-| host     | region  | measure_name     | time                          | value | average | location   | season | temperature | humidity |
-|----------|---------|------------------|-------------------------------|-------|---------|------------|--------|-------------|----------|
-| server01 | us-west | cpu_load_short   | 2024-08-30 23:07:54.000000000 | 0.64  | 1.24    |            |        |             |          |
-|          |         | weather          | 2024-01-22 26:07:33.000000000 |       |         | us-midwest | summer | 82.0        | 71.0     |
+| host     | region  | location   | season | measure_name     | time                          | value | average | temperature | humidity |
+|----------|---------|---------------------|------------------|-------------------------------|-------|---------|-------------|----------|
+| server01 | us-west |            |        | cpu_load_short   | 2024-08-30 23:07:54.000000000 | 0.64  | 1.24    |             |          |
+|          |         | us-midwest | summer | weather          | 2024-01-22 26:07:33.000000000 |       |         | 82.0        | 71.0     |
 
 
 ### Multi-Table Multi-Measure
@@ -74,7 +74,7 @@ weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480
 
 | location   | season  | measure_name     | time                          | temperature | humidity |
 |------------|---------|------------------|-------------------------------|-------------|----------|
-| us-midwest | summer  | influxdb-measure | 2024-01-22 26:0733.000000000 | 82.0        | 71.0     |
+| us-midwest | summer  | influxdb-measure | 2024-01-22 26:0733.000000000  | 82.0        | 71.0     |
 
 ## Deployment Options
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -73,6 +73,7 @@ The following parameters are available when deploying the connector as part of a
 | `RestApiGatewayTimeoutInMillis` | The maximum number of milliseconds a REST API Gateway event will wait before timing out. | `30000` |
 | `RustLog` | The log level to use for the Lambda function. Typical values are error, warn, info, debug, trace, and off. Use trace in order to log the execution time of each function. | `INFO` |
 | `WriteThrottlingBurstLimit` | The number of burst requests per second that the REST API Gateway permits. | `1200` |
+| `TableMapping` | Determines wether to ingest all records to a single table or to multiple tables. | `single-table` |
 
 ##### SAM Deployment Steps
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -30,7 +30,7 @@ The following example shows the translation of two line protocol points into a T
 #### Line Protocol Points
 
 ```
-cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274
+cpu_load_short,host=server01,region=us-west value=0.64,average=1.24 1725059274
 weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480990
 ```
 
@@ -60,7 +60,7 @@ The following example shows the translation of two line protocol points into two
 #### Line Protocol Points
 
 ```
-cpu_load_short,host=server01,region=us-west value=0.64,average=1.24, 1725059274
+cpu_load_short,host=server01,region=us-west value=0.64,average=1.24 1725059274
 weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480990
 ```
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -39,18 +39,26 @@ async fn handle_body(
 
     let line_protocol = str::from_utf8(body).unwrap();
     let metric_data = parse_line_protocol(line_protocol)?;
-    let multi_measure_builder = get_builder(SchemaType::MultiTableMultiMeasure(std::env::var(
-        "measure_name_for_multi_measure_records",
-    )?));
 
-    // Only currently supports multi-measure multi-table
+    let multi_measure_builder = match std::env::var("table_mapping")?.to_lowercase().as_str() {
+        "multi-table" => get_builder(
+            SchemaType::MultiTableMultiMeasure,
+            std::env::var("measure_name_for_multi_measure_records")?,
+        ),
+        _ => get_builder(
+            SchemaType::SingleTableMultiMeasure,
+            std::env::var("single_table_name")?,
+        ),
+    };
+
+    // Only currently supports multi-measure
     let multi_table_batch = build_records(&multi_measure_builder, &metric_data, precision)?;
-    handle_multi_table_ingestion(client, multi_table_batch).await?;
+    handle_ingestion(client, multi_table_batch).await?;
     Ok(())
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
-async fn handle_multi_table_ingestion(
+async fn handle_ingestion(
     client: &Arc<timestream_write::Client>,
     records: HashMap<String, Vec<timestream_write::types::Record>>,
 ) -> Result<(), Error> {

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
@@ -17,13 +17,13 @@ pub fn get_builder(schema: SchemaType, measure_name: String) -> impl BuildRecord
     match schema {
         SchemaType::SingleTableMultiMeasure => {
             return multi_measure_builder::MultiMeasureBuilder {
-                measure_name: measure_name.to_string(),
+                measure_name: None,
                 schema_type: SchemaType::SingleTableMultiMeasure,
             }
         }
         SchemaType::MultiTableMultiMeasure => {
             return multi_measure_builder::MultiMeasureBuilder {
-                measure_name: measure_name.to_string(),
+                measure_name: Some(measure_name.to_string()),
                 schema_type: SchemaType::MultiTableMultiMeasure,
             }
         }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
@@ -110,6 +110,33 @@ pub fn validate_env_variables() -> Result<(), Error> {
         }
     }
 
+    // Validate environment variables for table mapping
+    match std::env::var("table_mapping") {
+        Ok(table_mapping) => match table_mapping.as_str() {
+            "single-table" => {
+                if std::env::var("single_table_name").is_err() {
+                    return Err(anyhow!(
+                        "single_table_name environment variable is not defined"
+                    ));
+                }
+            }
+            "multi-table" => {
+                if std::env::var("measure_name_for_multi_measure_records").is_err() {
+                    return Err(anyhow!(
+                        "measure_name_for_multi_measure_records environment variable is not defined"
+                    ));
+                }
+            }
+            table_mapping => {
+                return Err(anyhow!(
+                    "{:?} is an invalid value for the table_mapping environment variable",
+                    table_mapping
+                ))
+            }
+        },
+        Err(_) => return Err(anyhow!("table_mapping environment variable is not defined")),
+    }
+
     // Customer-defined partition key environment variables
     let custom_partition_key_type = std::env::var("custom_partition_key_type");
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
@@ -1,31 +1,32 @@
 use crate::metric::Metric;
+use crate::timestream_utils::{DIMENSION_PARTITION_KEY_TYPE, MEASURE_PARTITION_KEY_TYPE};
 use anyhow::{anyhow, Error};
-use aws_sdk_timestreamwrite as timestream_write;
+use aws_sdk_timestreamwrite::types as timestream_types;
 use std::{collections::HashMap, fmt::Debug};
 
-mod multi_table_multi_measure_builder;
-
-const DIMENSION_PARTITION_KEY_TYPE: &str = "dimension";
-const MEASURE_PARTITION_KEY_TYPE: &str = "measure";
+mod multi_measure_builder;
 
 #[derive(Debug)]
 pub enum SchemaType {
-    MultiTableMultiMeasure(String),
-}
-
-impl std::fmt::Display for SchemaType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            SchemaType::MultiTableMultiMeasure(v) => std::fmt::Display::fmt(&v, f),
-        }
-    }
+    MultiTableMultiMeasure,
+    SingleTableMultiMeasure,
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
-pub fn get_builder(schema: SchemaType) -> impl BuildRecords {
-    // Currently only supported schema is multi-table multi-measure
-    multi_table_multi_measure_builder::MultiTableMultiMeasureBuilder {
-        measure_name: schema.to_string(),
+pub fn get_builder(schema: SchemaType, measure_name: String) -> impl BuildRecords {
+    match schema {
+        SchemaType::SingleTableMultiMeasure => {
+            return multi_measure_builder::MultiMeasureBuilder {
+                measure_name: measure_name.to_string(),
+                schema_type: SchemaType::SingleTableMultiMeasure,
+            }
+        }
+        SchemaType::MultiTableMultiMeasure => {
+            return multi_measure_builder::MultiMeasureBuilder {
+                measure_name: measure_name.to_string(),
+                schema_type: SchemaType::MultiTableMultiMeasure,
+            }
+        }
     }
 }
 
@@ -33,86 +34,9 @@ pub fn get_builder(schema: SchemaType) -> impl BuildRecords {
 pub fn build_records(
     records_builder: &impl BuildRecords,
     metrics: &[Metric],
-    precision: &timestream_write::types::TimeUnit,
-) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
+    precision: &timestream_types::TimeUnit,
+) -> Result<HashMap<String, Vec<timestream_types::Record>>, Error> {
     records_builder.build_records(metrics, precision)
-}
-
-#[derive(Debug)]
-pub struct TableConfig {
-    pub mag_store_retention_period: i64,
-    pub mem_store_retention_period: i64,
-    pub enable_mag_store_writes: bool,
-    pub enforce_custom_partition_key: Option<timestream_write::types::PartitionKeyEnforcementLevel>,
-    pub custom_partition_key_type: Option<timestream_write::types::PartitionKeyType>,
-    pub custom_partition_key_dimension: Option<String>,
-}
-
-#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
-pub fn get_table_config() -> Result<TableConfig, Error> {
-    // Get the populated table_config struct
-
-    let custom_partition_key_type = match std::env::var("custom_partition_key_type") {
-        Ok(custom_partition_key_type_value) => {
-            match custom_partition_key_type_value.to_lowercase().as_str() {
-                DIMENSION_PARTITION_KEY_TYPE => {
-                    Some(timestream_write::types::PartitionKeyType::Dimension)
-                }
-                MEASURE_PARTITION_KEY_TYPE => {
-                    Some(timestream_write::types::PartitionKeyType::Measure)
-                }
-                _ => None,
-            }
-        }
-        _ => None,
-    };
-
-    // If custom_partition_key_type is "dimension", then enforce_custom_partition_key is required (true or false).
-    // If custom_partition_key_type is "measure", then this will ignore enforce_custom_partition_key.
-    // The SDK will return an error if custom_partition_key_type is "measure" and any value is specified for
-    // enforce_custom_partition_key
-    let enforce_custom_partition_key = match custom_partition_key_type {
-        Some(timestream_write::types::PartitionKeyType::Dimension) => {
-            // enforce_custom_partition_key value (true or false) is required if custom_partition_key_type is PartitionKeyType::Dimension
-            match std::env::var("enforce_custom_partition_key")?
-                .to_lowercase()
-                .as_str()
-            {
-                "true" | "t" | "1" => {
-                    Some(timestream_write::types::PartitionKeyEnforcementLevel::Required)
-                }
-                "false" | "f" | "0" => {
-                    Some(timestream_write::types::PartitionKeyEnforcementLevel::Optional)
-                }
-                _ => None,
-            }
-        }
-        _ => None,
-    };
-
-    // If custom_partition_key_type is "dimension", then custom_partition_key_dimension is required.
-    // The SDK will return an error if custom_partition_key_type is "measure" and
-    // any value is specified for custom_partition_key_dimension
-    let custom_partition_key_dimension = match custom_partition_key_type {
-        Some(timestream_write::types::PartitionKeyType::Dimension) => {
-            Some(std::env::var("custom_partition_key_dimension")?)
-        }
-        _ => None,
-    };
-
-    Ok(TableConfig {
-        mag_store_retention_period: std::env::var("mag_store_retention_period")?.parse()?,
-        mem_store_retention_period: std::env::var("mem_store_retention_period")?.parse()?,
-        enable_mag_store_writes: matches!(
-            std::env::var("enable_mag_store_writes")?
-                .to_lowercase()
-                .as_str(),
-            "true" | "t" | "1"
-        ),
-        enforce_custom_partition_key,
-        custom_partition_key_type,
-        custom_partition_key_dimension,
-    })
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
@@ -229,8 +153,8 @@ pub trait BuildRecords: Debug {
     fn build_records(
         &self,
         metrics: &[Metric],
-        precision: &timestream_write::types::TimeUnit,
-    ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error>;
+        precision: &timestream_types::TimeUnit,
+    ) -> Result<HashMap<String, Vec<timestream_types::Record>>, Error>;
 }
 
 #[cfg(test)]

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_measure_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_measure_builder.rs
@@ -1,15 +1,19 @@
 use super::{validate_env_variables, BuildRecords};
-use crate::metric::{FieldValue, Metric};
+use crate::{
+    metric::{FieldValue, Metric},
+    SchemaType,
+};
 use anyhow::{anyhow, Error, Result};
 use aws_sdk_timestreamwrite as timestream_write;
 use std::collections::HashMap;
 
-pub struct MultiTableMultiMeasureBuilder {
+pub struct MultiMeasureBuilder {
     pub measure_name: String,
+    pub schema_type: SchemaType,
 }
 
-impl BuildRecords for MultiTableMultiMeasureBuilder {
-    // trait implementation to support multi-measure multi-table schema with Timestream
+impl BuildRecords for MultiMeasureBuilder {
+    // trait implementation to support multi-measure records Timestream
 
     #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
     fn build_records(
@@ -19,11 +23,26 @@ impl BuildRecords for MultiTableMultiMeasureBuilder {
     ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
         validate_env_variables()?;
         validate_multi_measure_env_variables()?;
-        build_multi_measure_records(metrics, &self.measure_name, precision)
+        match self.schema_type {
+            SchemaType::SingleTableMultiMeasure => {
+                return build_single_table_multi_measure_records(
+                    metrics,
+                    &self.measure_name,
+                    precision,
+                )
+            }
+            SchemaType::MultiTableMultiMeasure => {
+                return build_multi_table_multi_measure_records(
+                    metrics,
+                    &self.measure_name,
+                    precision,
+                )
+            }
+        }
     }
 }
 
-impl std::fmt::Debug for MultiTableMultiMeasureBuilder {
+impl std::fmt::Debug for MultiMeasureBuilder {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.measure_name)
     }
@@ -31,38 +50,77 @@ impl std::fmt::Debug for MultiTableMultiMeasureBuilder {
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 fn validate_multi_measure_env_variables() -> Result<(), Error> {
-    // Validate environment variables for multi-measure schema types
+    // Validate environment variables for multi-measure records
 
-    if std::env::var("measure_name_for_multi_measure_records").is_err() {
-        return Err(anyhow!(
-            "measure_name_for_multi_measure_records environment variable is not defined"
-        ));
+    match std::env::var("table_mapping") {
+        Ok(table_mapping) => match table_mapping.as_str() {
+            "single-table" => {
+                if std::env::var("single_table_name").is_err() {
+                    return Err(anyhow!(
+                        "single_table_name environment variable is not defined"
+                    ));
+                }
+            }
+            "multi-table" => {
+                if std::env::var("measure_name_for_multi_measure_records").is_err() {
+                    return Err(anyhow!(
+                        "measure_name_for_multi_measure_records environment variable is not defined"
+                    ));
+                }
+            }
+            table_mapping => {
+                return Err(anyhow!(
+                    "{:?} is an invalid value for the table_mapping environment variable",
+                    table_mapping
+                ))
+            }
+        },
+        Err(_) => return Err(anyhow!("table_mapping environment variable is not defined")),
     }
 
     Ok(())
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
-fn build_multi_measure_records(
+fn build_single_table_multi_measure_records(
     metrics: &[Metric],
     measure_name: &str,
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
-    // Builds multi-measure multi-table records hashmap
+    // Builds multi-measure records hashmap all to one table
 
-    let mut multi_table_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
+    let mut records_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
+        HashMap::new();
+    let table_name = std::env::var("single_table_name")?;
+    for metric in metrics.iter() {
+        let new_record = metric_to_timestream_record(measure_name, metric, precision)?;
+        records_batch.insert(table_name.to_string(), vec![new_record]);
+    }
+
+    Ok(records_batch)
+}
+
+#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
+fn build_multi_table_multi_measure_records(
+    metrics: &[Metric],
+    measure_name: &str,
+    precision: &timestream_write::types::TimeUnit,
+) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
+    // Builds multi-measure records hashmap to multiple tables
+
+    let mut records_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
         HashMap::new();
     for metric in metrics.iter() {
         let new_record = metric_to_timestream_record(measure_name, metric, precision)?;
         let table_name = metric.name();
-        if let Some(record_vec) = multi_table_batch.get_mut(table_name) {
+        if let Some(record_vec) = records_batch.get_mut(table_name) {
             record_vec.push(new_record);
         } else {
-            multi_table_batch.insert(table_name.to_string(), vec![new_record]);
+            records_batch.insert(table_name.to_string(), vec![new_record]);
         }
     }
 
-    Ok(multi_table_batch)
+    Ok(records_batch)
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_measure_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_measure_builder.rs
@@ -8,7 +8,7 @@ use aws_sdk_timestreamwrite as timestream_write;
 use std::collections::HashMap;
 
 pub struct MultiMeasureBuilder {
-    pub measure_name: String,
+    pub measure_name: Option<String>,
     pub schema_type: SchemaType,
 }
 
@@ -24,16 +24,12 @@ impl BuildRecords for MultiMeasureBuilder {
         validate_env_variables()?;
         match self.schema_type {
             SchemaType::SingleTableMultiMeasure => {
-                return build_single_table_multi_measure_records(
-                    metrics,
-                    &self.measure_name,
-                    precision,
-                )
+                return build_single_table_multi_measure_records(metrics, precision)
             }
             SchemaType::MultiTableMultiMeasure => {
                 return build_multi_table_multi_measure_records(
                     metrics,
-                    &self.measure_name,
+                    self.measure_name.as_deref(),
                     precision,
                 )
             }
@@ -43,14 +39,20 @@ impl BuildRecords for MultiMeasureBuilder {
 
 impl std::fmt::Debug for MultiMeasureBuilder {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(formatter, "{}", self.measure_name)
+        write!(
+            formatter,
+            "{}",
+            self.measure_name
+                .as_deref()
+                .expect("Failed to unwrap")
+                .to_owned()
+        )
     }
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 fn build_single_table_multi_measure_records(
     metrics: &[Metric],
-    measure_name: &str,
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
     // Builds multi-measure records hashmap to be ingested to one table
@@ -59,7 +61,7 @@ fn build_single_table_multi_measure_records(
         HashMap::new();
     let table_name = std::env::var("single_table_name")?;
     for metric in metrics.iter() {
-        let new_record = metric_to_timestream_record(measure_name, metric, precision)?;
+        let new_record = metric_to_timestream_record(metric.name(), metric, precision)?;
         if let Some(record_vec) = records_batch.get_mut(&table_name) {
             record_vec.push(new_record);
         } else {
@@ -73,7 +75,7 @@ fn build_single_table_multi_measure_records(
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 fn build_multi_table_multi_measure_records(
     metrics: &[Metric],
-    measure_name: &str,
+    measure_name: Option<&str>,
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
     // Builds multi-measure records hashmap to be ingested to multiple tables
@@ -81,7 +83,11 @@ fn build_multi_table_multi_measure_records(
     let mut records_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
         HashMap::new();
     for metric in metrics.iter() {
-        let new_record = metric_to_timestream_record(measure_name, metric, precision)?;
+        let new_record = metric_to_timestream_record(
+            measure_name.expect("Failed to unwrap"),
+            metric,
+            precision,
+        )?;
         let table_name = metric.name();
         if let Some(record_vec) = records_batch.get_mut(table_name) {
             record_vec.push(new_record);

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_measure_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/multi_measure_builder.rs
@@ -3,7 +3,7 @@ use crate::{
     metric::{FieldValue, Metric},
     SchemaType,
 };
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result};
 use aws_sdk_timestreamwrite as timestream_write;
 use std::collections::HashMap;
 
@@ -22,7 +22,6 @@ impl BuildRecords for MultiMeasureBuilder {
         precision: &timestream_write::types::TimeUnit,
     ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
         validate_env_variables()?;
-        validate_multi_measure_env_variables()?;
         match self.schema_type {
             SchemaType::SingleTableMultiMeasure => {
                 return build_single_table_multi_measure_records(
@@ -49,52 +48,23 @@ impl std::fmt::Debug for MultiMeasureBuilder {
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
-fn validate_multi_measure_env_variables() -> Result<(), Error> {
-    // Validate environment variables for multi-measure records
-
-    match std::env::var("table_mapping") {
-        Ok(table_mapping) => match table_mapping.as_str() {
-            "single-table" => {
-                if std::env::var("single_table_name").is_err() {
-                    return Err(anyhow!(
-                        "single_table_name environment variable is not defined"
-                    ));
-                }
-            }
-            "multi-table" => {
-                if std::env::var("measure_name_for_multi_measure_records").is_err() {
-                    return Err(anyhow!(
-                        "measure_name_for_multi_measure_records environment variable is not defined"
-                    ));
-                }
-            }
-            table_mapping => {
-                return Err(anyhow!(
-                    "{:?} is an invalid value for the table_mapping environment variable",
-                    table_mapping
-                ))
-            }
-        },
-        Err(_) => return Err(anyhow!("table_mapping environment variable is not defined")),
-    }
-
-    Ok(())
-}
-
-#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 fn build_single_table_multi_measure_records(
     metrics: &[Metric],
     measure_name: &str,
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
-    // Builds multi-measure records hashmap all to one table
+    // Builds multi-measure records hashmap to be ingested to one table
 
     let mut records_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
         HashMap::new();
     let table_name = std::env::var("single_table_name")?;
     for metric in metrics.iter() {
         let new_record = metric_to_timestream_record(measure_name, metric, precision)?;
-        records_batch.insert(table_name.to_string(), vec![new_record]);
+        if let Some(record_vec) = records_batch.get_mut(&table_name) {
+            record_vec.push(new_record);
+        } else {
+            records_batch.insert(table_name.to_string(), vec![new_record]);
+        }
     }
 
     Ok(records_batch)
@@ -106,7 +76,7 @@ fn build_multi_table_multi_measure_records(
     measure_name: &str,
     precision: &timestream_write::types::TimeUnit,
 ) -> Result<HashMap<String, Vec<timestream_write::types::Record>>, Error> {
-    // Builds multi-measure records hashmap to multiple tables
+    // Builds multi-measure records hashmap to be ingested to multiple tables
 
     let mut records_batch: HashMap<String, Vec<aws_sdk_timestreamwrite::types::Record>> =
         HashMap::new();

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
@@ -10,9 +10,11 @@ fn test_mtmm_single_record() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
-    let multi_table_multi_measure_schema =
-        super::SchemaType::MultiTableMultiMeasure(String::from("influxdb-connector-measure"));
-    let multi_table_multi_measure_builder = super::get_builder(multi_table_multi_measure_schema);
+    let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
+    let multi_table_multi_measure_builder = super::get_builder(
+        multi_table_multi_measure_schema,
+        String::from("influxdb-connector-measure"),
+    );
     let metrics = [Metric::new(
         "readings".to_string(),
         vec![(String::from("goal"), String::from("baseline"))].into(),
@@ -66,9 +68,11 @@ fn test_mtmm_single_destination() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
-    let multi_table_multi_measure_schema =
-        super::SchemaType::MultiTableMultiMeasure(String::from("influxdb-connector-measure"));
-    let multi_table_multi_measure_builder = super::get_builder(multi_table_multi_measure_schema);
+    let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
+    let multi_table_multi_measure_builder = super::get_builder(
+        multi_table_multi_measure_schema,
+        String::from("influxdb-connector-measure"),
+    );
     let metrics = [
         Metric::new(
             "readings".to_string(),
@@ -152,9 +156,11 @@ fn test_mtmm_multi_record() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
-    let multi_table_multi_measure_schema =
-        super::SchemaType::MultiTableMultiMeasure(String::from("influxdb-connector-measure"));
-    let multi_table_multi_measure_builder = super::get_builder(multi_table_multi_measure_schema);
+    let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
+    let multi_table_multi_measure_builder = super::get_builder(
+        multi_table_multi_measure_schema,
+        String::from("influxdb-connector-measure"),
+    );
     let metrics = [
         Metric::new(
             "readings".to_string(),
@@ -239,9 +245,11 @@ fn test_mtmm_empty_dimensions() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
-    let multi_table_multi_measure_schema =
-        super::SchemaType::MultiTableMultiMeasure(String::from("influxdb-connector-measure"));
-    let multi_table_multi_measure_builder = super::get_builder(multi_table_multi_measure_schema);
+    let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
+    let multi_table_multi_measure_builder = super::get_builder(
+        multi_table_multi_measure_schema,
+        String::from("influxdb-connector-measure"),
+    );
     let metrics = [Metric::new(
         "readings".to_string(),
         None,
@@ -286,9 +294,11 @@ fn test_mtmm_varying_timestamp_records() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
-    let multi_table_multi_measure_schema =
-        super::SchemaType::MultiTableMultiMeasure(String::from("influxdb-connector-measure"));
-    let multi_table_multi_measure_builder = super::get_builder(multi_table_multi_measure_schema);
+    let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
+    let multi_table_multi_measure_builder = super::get_builder(
+        multi_table_multi_measure_schema,
+        String::from("influxdb-connector-measure"),
+    );
     let metrics = [
         Metric::new(
             "readings".to_string(),

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
@@ -541,7 +541,7 @@ fn setup_table_mapping_env_variables(schema_type: super::SchemaType) {
             env::set_var("table_mapping", "multi-table");
         }
         super::SchemaType::SingleTableMultiMeasure => {
-            env::set_var("table_mapping", "multi-table");
+            env::set_var("table_mapping", "single-table");
             env::set_var("single_table_name", "influxdb-measures");
         }
     }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
@@ -10,6 +10,7 @@ fn test_mtmm_single_record() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
         multi_table_multi_measure_schema,
@@ -68,6 +69,7 @@ fn test_mtmm_single_destination() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
         multi_table_multi_measure_schema,
@@ -156,6 +158,7 @@ fn test_mtmm_multi_record() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
         multi_table_multi_measure_schema,
@@ -245,6 +248,7 @@ fn test_mtmm_empty_dimensions() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
         multi_table_multi_measure_schema,
@@ -294,6 +298,7 @@ fn test_mtmm_varying_timestamp_records() -> Result<(), Error> {
 
     setup_minimal_env_vars();
     setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
         multi_table_multi_measure_schema,
@@ -388,8 +393,163 @@ fn test_mtmm_varying_timestamp_records() -> Result<(), Error> {
     Ok(())
 }
 
+#[test]
+fn test_stmm_single_record() -> Result<(), Error> {
+    // Single measure for multi-measure record
+
+    setup_minimal_env_vars();
+    setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::SingleTableMultiMeasure);
+    let single_table_multi_measure_builder = super::get_builder(
+        super::SchemaType::SingleTableMultiMeasure,
+        String::from("influxdb-connector-measure"),
+    );
+    let metrics = [Metric::new(
+        "readings".to_string(),
+        vec![(String::from("goal"), String::from("baseline"))].into(),
+        vec![(String::from("incline"), FieldValue::I64(125))],
+        1577836800000,
+    )];
+
+    let records = build_records(
+        &single_table_multi_measure_builder,
+        &metrics,
+        &timestream_write::types::TimeUnit::Nanoseconds,
+    )?;
+    assert_eq!(records.len(), 1);
+    // Table name should align with environment variable
+    let first_record = records
+        .get("influxdb-measures")
+        .expect("Failed to unwrap")
+        .first()
+        .expect("Failed to unwrap");
+    assert_eq!(first_record.time, Some(String::from("1577836800000")));
+
+    assert_eq!(
+        first_record.measure_name(),
+        Some("influxdb-connector-measure")
+    );
+    assert_eq!(
+        first_record.measure_value_type(),
+        Some(&timestream_write::types::MeasureValueType::Multi)
+    );
+    assert!(first_record.measure_values().contains(
+        &timestream_write::types::MeasureValue::builder()
+            .name(String::from("incline"))
+            .value(String::from("125"))
+            .r#type(timestream_write::types::MeasureValueType::Bigint)
+            .build()
+            .expect("Failed to build measure")
+    ));
+    assert!(first_record.dimensions().contains(
+        &timestream_write::types::Dimension::builder()
+            .name(String::from("goal"))
+            .value(String::from("baseline"))
+            .build()
+            .expect("Failed to build dimension")
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn test_stmm_multi_record() -> Result<(), Error> {
+    // Dataset with differing metric names going to the same table
+
+    setup_minimal_env_vars();
+    setup_multi_measure_env_vars();
+    setup_table_mapping_env_variables(super::SchemaType::SingleTableMultiMeasure);
+    let single_table_multi_measure_builder = super::get_builder(
+        super::SchemaType::SingleTableMultiMeasure,
+        String::from("influxdb-connector-measure"),
+    );
+    let metrics = [
+        Metric::new(
+            "readings".to_string(),
+            vec![(String::from("goal"), String::from("baseline"))].into(),
+            vec![(String::from("incline"), FieldValue::I64(125))],
+            1577836800000,
+        ),
+        Metric::new(
+            "velocity".to_string(),
+            vec![(String::from("goal"), String::from("baseline"))].into(),
+            vec![(String::from("km/h"), FieldValue::F64(4.6))],
+            1577836911132,
+        ),
+    ];
+
+    let records = build_records(
+        &single_table_multi_measure_builder,
+        &metrics,
+        &timestream_write::types::TimeUnit::Nanoseconds,
+    )?;
+    // All items should only be going to one table
+    assert_eq!(records.len(), 1);
+    // Table name should align with environment variable
+    let records_vec = records.get("influxdb-measures").expect("failed to unwrap");
+    let readings = records_vec.first().expect("Failed to unwrap");
+    let velocity = records_vec.get(1).expect("Failed to unwrap");
+    assert_eq!(readings.time, Some(String::from("1577836800000")));
+    assert_eq!(velocity.time, Some(String::from("1577836911132")));
+
+    assert_eq!(readings.measure_name(), Some("influxdb-connector-measure"));
+    assert_eq!(velocity.measure_name(), Some("influxdb-connector-measure"));
+    assert_eq!(
+        readings.measure_value_type(),
+        Some(&timestream_write::types::MeasureValueType::Multi)
+    );
+    assert_eq!(
+        velocity.measure_value_type(),
+        Some(&timestream_write::types::MeasureValueType::Multi)
+    );
+    assert!(readings.measure_values().contains(
+        &timestream_write::types::MeasureValue::builder()
+            .name(String::from("incline"))
+            .value(String::from("125"))
+            .r#type(timestream_write::types::MeasureValueType::Bigint)
+            .build()
+            .expect("Failed to build measure")
+    ));
+    assert!(readings.dimensions().contains(
+        &timestream_write::types::Dimension::builder()
+            .name(String::from("goal"))
+            .value(String::from("baseline"))
+            .build()
+            .expect("Failed to build dimension")
+    ));
+    assert!(velocity.measure_values().contains(
+        &timestream_write::types::MeasureValue::builder()
+            .name(String::from("km/h"))
+            .value(String::from("4.6"))
+            .r#type(timestream_write::types::MeasureValueType::Double)
+            .build()
+            .expect("Failed to build measure")
+    ));
+    assert!(velocity.dimensions().contains(
+        &timestream_write::types::Dimension::builder()
+            .name(String::from("goal"))
+            .value(String::from("baseline"))
+            .build()
+            .expect("Failed to build dimension")
+    ));
+
+    Ok(())
+}
+
 fn setup_multi_measure_env_vars() {
     env::set_var("measure_name_for_multi_measure_records", "influxdb-measure");
+}
+
+fn setup_table_mapping_env_variables(schema_type: super::SchemaType) {
+    match schema_type {
+        super::SchemaType::MultiTableMultiMeasure => {
+            env::set_var("table_mapping", "multi-table");
+        }
+        super::SchemaType::SingleTableMultiMeasure => {
+            env::set_var("table_mapping", "multi-table");
+            env::set_var("single_table_name", "influxdb-measures");
+        }
+    }
 }
 
 fn setup_minimal_env_vars() {

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder/tests.rs
@@ -9,7 +9,7 @@ fn test_mtmm_single_record() -> Result<(), Error> {
     // Single measure for multi-measure record
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
+    setup_multi_table_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
@@ -68,7 +68,7 @@ fn test_mtmm_single_destination() -> Result<(), Error> {
     // Dataset all going to same table
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
+    setup_multi_table_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
@@ -157,7 +157,7 @@ fn test_mtmm_multi_record() -> Result<(), Error> {
     // Dataset going to multiple table destinations
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
+    setup_multi_table_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
@@ -247,7 +247,7 @@ fn test_mtmm_empty_dimensions() -> Result<(), Error> {
     // Dataset with empty dimensions
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
+    setup_multi_table_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
@@ -297,7 +297,7 @@ fn test_mtmm_varying_timestamp_records() -> Result<(), Error> {
     // Varying timestamp parsing
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
+    setup_multi_table_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::MultiTableMultiMeasure);
     let multi_table_multi_measure_schema = super::SchemaType::MultiTableMultiMeasure;
     let multi_table_multi_measure_builder = super::get_builder(
@@ -398,7 +398,6 @@ fn test_stmm_single_record() -> Result<(), Error> {
     // Single measure for multi-measure record
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::SingleTableMultiMeasure);
     let single_table_multi_measure_builder = super::get_builder(
         super::SchemaType::SingleTableMultiMeasure,
@@ -425,10 +424,7 @@ fn test_stmm_single_record() -> Result<(), Error> {
         .expect("Failed to unwrap");
     assert_eq!(first_record.time, Some(String::from("1577836800000")));
 
-    assert_eq!(
-        first_record.measure_name(),
-        Some("influxdb-connector-measure")
-    );
+    assert_eq!(first_record.measure_name(), Some("readings"));
     assert_eq!(
         first_record.measure_value_type(),
         Some(&timestream_write::types::MeasureValueType::Multi)
@@ -457,7 +453,6 @@ fn test_stmm_multi_record() -> Result<(), Error> {
     // Dataset with differing metric names going to the same table
 
     setup_minimal_env_vars();
-    setup_multi_measure_env_vars();
     setup_table_mapping_env_variables(super::SchemaType::SingleTableMultiMeasure);
     let single_table_multi_measure_builder = super::get_builder(
         super::SchemaType::SingleTableMultiMeasure,
@@ -492,8 +487,8 @@ fn test_stmm_multi_record() -> Result<(), Error> {
     assert_eq!(readings.time, Some(String::from("1577836800000")));
     assert_eq!(velocity.time, Some(String::from("1577836911132")));
 
-    assert_eq!(readings.measure_name(), Some("influxdb-connector-measure"));
-    assert_eq!(velocity.measure_name(), Some("influxdb-connector-measure"));
+    assert_eq!(readings.measure_name(), Some("readings"));
+    assert_eq!(velocity.measure_name(), Some("velocity"));
     assert_eq!(
         readings.measure_value_type(),
         Some(&timestream_write::types::MeasureValueType::Multi)
@@ -536,7 +531,7 @@ fn test_stmm_multi_record() -> Result<(), Error> {
     Ok(())
 }
 
-fn setup_multi_measure_env_vars() {
+fn setup_multi_table_multi_measure_env_vars() {
     env::set_var("measure_name_for_multi_measure_records", "influxdb-measure");
 }
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
@@ -1,4 +1,3 @@
-use super::records_builder::TableConfig;
 use anyhow::{anyhow, Error, Result};
 use aws_sdk_timestreamwrite as timestream_write;
 use aws_types::region::Region;
@@ -13,6 +12,19 @@ use tokio::task;
 // The maximum number of threads to use for ingesting
 // batches of records to Timestream in parallel
 static NUM_TIMESTREAM_INGEST_THREADS: usize = 12;
+
+pub const DIMENSION_PARTITION_KEY_TYPE: &str = "dimension";
+pub const MEASURE_PARTITION_KEY_TYPE: &str = "measure";
+
+#[derive(Debug)]
+pub struct TableConfig {
+    pub mag_store_retention_period: i64,
+    pub mem_store_retention_period: i64,
+    pub enable_mag_store_writes: bool,
+    pub enforce_custom_partition_key: Option<timestream_write::types::PartitionKeyEnforcementLevel>,
+    pub custom_partition_key_type: Option<timestream_write::types::PartitionKeyType>,
+    pub custom_partition_key_dimension: Option<String>,
+}
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 pub async fn get_connection(
@@ -152,6 +164,73 @@ pub async fn database_exists(
             _ => Err(anyhow!(error)),
         },
     }
+}
+
+#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
+pub fn get_table_config() -> Result<TableConfig, Error> {
+    // Get the populated table_config struct
+
+    let custom_partition_key_type = match std::env::var("custom_partition_key_type") {
+        Ok(custom_partition_key_type_value) => {
+            match custom_partition_key_type_value.to_lowercase().as_str() {
+                DIMENSION_PARTITION_KEY_TYPE => {
+                    Some(timestream_write::types::PartitionKeyType::Dimension)
+                }
+                MEASURE_PARTITION_KEY_TYPE => {
+                    Some(timestream_write::types::PartitionKeyType::Measure)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+
+    // If custom_partition_key_type is "dimension", then enforce_custom_partition_key is required (true or false).
+    // If custom_partition_key_type is "measure", then this will ignore enforce_custom_partition_key.
+    // The SDK will return an error if custom_partition_key_type is "measure" and any value is specified for
+    // enforce_custom_partition_key
+    let enforce_custom_partition_key = match custom_partition_key_type {
+        Some(timestream_write::types::PartitionKeyType::Dimension) => {
+            // enforce_custom_partition_key value (true or false) is required if custom_partition_key_type is PartitionKeyType::Dimension
+            match std::env::var("enforce_custom_partition_key")?
+                .to_lowercase()
+                .as_str()
+            {
+                "true" | "t" | "1" => {
+                    Some(timestream_write::types::PartitionKeyEnforcementLevel::Required)
+                }
+                "false" | "f" | "0" => {
+                    Some(timestream_write::types::PartitionKeyEnforcementLevel::Optional)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    };
+
+    // If custom_partition_key_type is "dimension", then custom_partition_key_dimension is required.
+    // The SDK will return an error if custom_partition_key_type is "measure" and
+    // any value is specified for custom_partition_key_dimension
+    let custom_partition_key_dimension = match custom_partition_key_type {
+        Some(timestream_write::types::PartitionKeyType::Dimension) => {
+            Some(std::env::var("custom_partition_key_dimension")?)
+        }
+        _ => None,
+    };
+
+    Ok(TableConfig {
+        mag_store_retention_period: std::env::var("mag_store_retention_period")?.parse()?,
+        mem_store_retention_period: std::env::var("mem_store_retention_period")?.parse()?,
+        enable_mag_store_writes: matches!(
+            std::env::var("enable_mag_store_writes")?
+                .to_lowercase()
+                .as_str(),
+            "true" | "t" | "1"
+        ),
+        enforce_custom_partition_key,
+        custom_partition_key_type,
+        custom_partition_key_dimension,
+    })
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -36,6 +36,10 @@ Parameters:
     Type: String
     Default: single-table
     Description: Maps records ingested to a single table or multiple tables.
+  SingleTableName:
+    Type: String
+    Default: influxdb-measures
+    Description: Name of the table when table_mapping is set to single-table.
   EnableAsyncInvocation:
     Type: String
     AllowedValues:
@@ -363,7 +367,6 @@ Resources:
   AsyncRestApiGatewayStage:
     Type: AWS::ApiGateway::Stage
     Condition: IsAsyncEnabled
-    DependsOn: AsyncRestApiGatewayDeployment
     Properties:
       StageName: !Ref RestApiGatewayStageName
       RestApiId: !Ref RestApiGateway
@@ -385,7 +388,6 @@ Resources:
   SyncRestApiGatewayStage:
     Type: AWS::ApiGateway::Stage
     Condition: IsSyncEnabled
-    DependsOn: SyncRestApiGatewayDeployment
     Properties:
       StageName: !Ref RestApiGatewayStageName
       RestApiId: !Ref RestApiGateway
@@ -546,6 +548,7 @@ Resources:
           database_name: !Ref DatabaseName
           measure_name_for_multi_measure_records: !Ref MeasureNameForMultiMeasureRecords
           table_mapping: !Ref TableMapping
+          single_table_name: !Ref SingleTableName
           region: !Ref AWS::Region
           enable_database_creation: !Ref EnableDatabaseCreation
           enable_table_creation: !Ref EnableTableCreation

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -32,6 +32,10 @@ Parameters:
     Type: String
     Default: influxdb-measure
     Description: The value to use in records as the measure name.
+  TableMapping:
+    Type: String
+    Default: single-table
+    Description: Maps records ingested to a single table or multiple tables.
   EnableAsyncInvocation:
     Type: String
     AllowedValues:
@@ -541,6 +545,7 @@ Resources:
           custom_partition_key_dimension: !If [CustomPartitionKeyDimensionProvided, !Ref CustomPartitionKeyDimension, !Ref "AWS::NoValue"]
           database_name: !Ref DatabaseName
           measure_name_for_multi_measure_records: !Ref MeasureNameForMultiMeasureRecords
+          table_mapping: !Ref TableMapping
           region: !Ref AWS::Region
           enable_database_creation: !Ref EnableDatabaseCreation
           enable_table_creation: !Ref EnableTableCreation

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -2,6 +2,7 @@ use anyhow::Error;
 use aws_credential_types::Credentials;
 use aws_sdk_timestreamwrite as timestream_write;
 use aws_types::region::Region;
+use influxdb_timestream_connector::records_builder::SchemaType;
 use lambda_runtime::{Context, LambdaEvent};
 use rand::{distributions::uniform::SampleUniform, distributions::Alphanumeric, Rng};
 use serde_json::{json, Value};
@@ -57,7 +58,19 @@ impl CleanupBatch {
     }
 }
 
-fn set_environment_variables() {
+fn set_table_mapping_env_variables(schema_type: SchemaType) {
+    match schema_type {
+        SchemaType::MultiTableMultiMeasure => {
+            env::set_var("table_mapping", "multi-table");
+        }
+        SchemaType::SingleTableMultiMeasure => {
+            env::set_var("table_mapping", "multi-table");
+            env::set_var("single_table_name", "influxdb-measures");
+        }
+    }
+}
+
+fn set_base_environment_variables() {
     env::set_var("database_name", DATABASE_NAME);
     env::set_var("enable_database_creation", "true");
     env::set_var("enable_table_creation", "true");
@@ -96,7 +109,8 @@ fn random_number<T: PartialOrd + SampleUniform>(low: T, high: T) -> T {
 #[tokio::test]
 async fn test_mtmm_basic() -> Result<(), Error> {
     // Tests ingesting a single point.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -132,7 +146,8 @@ async fn test_mtmm_basic() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_create_database() -> Result<(), Error> {
     // Tests ingesting a single point and creating a database.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let test_create_database_name = "test_create_database_influxdb_timestream_connector_integ";
     env::set_var("database_name", test_create_database_name);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
@@ -184,7 +199,8 @@ async fn test_mtmm_create_database() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_unusual_query_parameters() -> Result<(), Error> {
     // Tests ingesting a single point with a query parameters key with unusual spelling.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -220,7 +236,8 @@ async fn test_mtmm_unusual_query_parameters() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_no_query_parameters() -> Result<(), Error> {
     // Tests ingesting a single point without query parameters.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -254,7 +271,8 @@ async fn test_mtmm_multiple_timestamps() -> Result<(), Error> {
     // Tests ingesting a single point with two timestamps.
     // Note, the connector either returns JSON with a 200 status code or an Error. This is so that
     // the dead letter queue works when the connector is deployed as part of a stack.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -289,7 +307,8 @@ async fn test_mtmm_multiple_timestamps() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_many_tags_many_fields() -> Result<(), Error> {
     // Tests ingesting a single point with 50 tags and 50 fields.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -337,7 +356,8 @@ async fn test_mtmm_many_tags_many_fields() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_float() -> Result<(), Error> {
     // Tests ingesting a single point with a float value for the field.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -373,7 +393,8 @@ async fn test_mtmm_float() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_string() -> Result<(), Error> {
     // Tests ingesting a single point with a string value for the field.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -409,7 +430,8 @@ async fn test_mtmm_string() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_bool() -> Result<(), Error> {
     // Tests ingesting a single point with a bool value for the field.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -448,7 +470,8 @@ async fn test_mtmm_max_tag_length() -> Result<(), Error> {
     // is 60, the maximum allowed dimension name length, and its value
     // is 1988 characters long. The length of the tag key and tag value
     // together amount to the maximum size for a dimension pair, 2 kilobytes.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -488,7 +511,8 @@ async fn test_mtmm_beyond_max_tag_length() -> Result<(), Error> {
     // is 60, the maximum allowed dimension name length, and its value
     // is 1989 characters long. The length of the tag key and tag value
     // together exceed the maximum size for a dimension pair, 2 kilobytes.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -525,7 +549,8 @@ async fn test_mtmm_max_field_length() -> Result<(), Error> {
     // Tests ingesting a single point with a field where the length
     // of the field key is the maximum measure name, 256, and the length
     // of the field value is the maximum measure value size, 2048.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -564,7 +589,8 @@ async fn test_mtmm_beyond_max_field_length() -> Result<(), Error> {
     // Tests ingesting a single point with a field where the length
     // of the field key is the maximum measure name, 256, and the length
     // of the field value is beyond the maximum measure value size, 2048.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -601,7 +627,8 @@ async fn test_mtmm_max_unique_field_keys() -> Result<(), Error> {
     // Tests ingesting a batch of points where the number of unique field keys
     // in the batch equals the maximum number of unique measures for a single
     // table, 1024.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -644,7 +671,8 @@ async fn test_mtmm_beyond_max_unique_field_keys() -> Result<(), Error> {
     // Tests ingesting a batch of points where the number of unique field keys
     // in the batch exceeds the maximum number of unique measures for a single
     // table, 1024.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -686,7 +714,8 @@ async fn test_mtmm_max_unique_tag_keys() -> Result<(), Error> {
     // Tests ingesting a batch of points where the number of unique tag keys
     // in the batch equals the maximum number of unique dimensions for a single
     // table, 128.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -729,7 +758,8 @@ async fn test_mtmm_beyond_max_unique_tag_keys() -> Result<(), Error> {
     // Tests ingesting a batch of points where the number of unique tag keys
     // in the batch exceeds the maximum number of unique dimensions for a single
     // table, 128.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -771,7 +801,8 @@ async fn test_mtmm_max_table_name_length() -> Result<(), Error> {
     // Tests ingesting a single point with measurement with length
     // equal to the maximum number of bytes a Timestream table name can
     // have.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -809,7 +840,8 @@ async fn test_mtmm_beyond_max_table_name_length() -> Result<(), Error> {
     // Tests ingesting a single point with measurement with length
     // exceeding the maximum number of bytes a Timestream table name can
     // have.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -843,7 +875,8 @@ async fn test_mtmm_beyond_max_table_name_length() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_nanosecond_precision() -> Result<(), Error> {
     // Tests ingesting a single point with nanosecond precision.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -881,7 +914,8 @@ async fn test_mtmm_nanosecond_precision() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_microsecond_precision() -> Result<(), Error> {
     // Tests ingesting a single point with microsecond precision.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -917,7 +951,8 @@ async fn test_mtmm_microsecond_precision() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_second_precision() -> Result<(), Error> {
     // Tests ingesting a single point with second precision.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -953,7 +988,8 @@ async fn test_mtmm_second_precision() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_no_precision() -> Result<(), Error> {
     // Tests ingesting a single point without precision supplied.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -992,7 +1028,8 @@ async fn test_mtmm_no_precision() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_empty_point() -> Result<(), Error> {
     // Tests ingesting an empty string.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -1016,7 +1053,8 @@ async fn test_mtmm_empty_point() -> Result<(), Error> {
 #[tokio::test]
 pub async fn test_mtmm_small_timestamp() -> Result<(), Error> {
     // Tests ingesting with a single-digit millisecond timestamp.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -1052,7 +1090,8 @@ pub async fn test_mtmm_small_timestamp() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_5_measurements() -> Result<(), Error> {
     // Tests ingesting a batch with five measurements.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -1096,7 +1135,8 @@ async fn test_mtmm_5_measurements() -> Result<(), Error> {
 #[tokio::test]
 async fn test_mtmm_100_measurements() -> Result<(), Error> {
     // Tests ingesting a batch with 100 measurements.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");
@@ -1141,7 +1181,8 @@ async fn test_mtmm_100_measurements() -> Result<(), Error> {
 async fn test_mtmm_5000_batch() -> Result<(), Error> {
     // Tests ingesting a batch of 5000 points with a single measurement.
     // 5000 is the recommended batch size for InfluxDB v2 OSS.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     // Cleanup
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
@@ -1183,7 +1224,8 @@ async fn test_mtmm_5000_batch() -> Result<(), Error> {
 #[should_panic]
 async fn test_mtmm_no_credentials() {
     // Tests ingesting without AWS credentials. This test should panic.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
 
     let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .credentials_provider(Credentials::new("", "", None, None, "test"))
@@ -1221,7 +1263,8 @@ async fn test_mtmm_no_credentials() {
 #[should_panic]
 async fn test_mtmm_incorrect_credentials() {
     // Tests ingesting with incorrect AWS credentials. This test should panic.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
 
     let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .credentials_provider(Credentials::new(
@@ -1265,7 +1308,8 @@ async fn test_mtmm_incorrect_credentials() {
 async fn test_mtmm_custom_dimension_partition_key_optional_enforcement() -> Result<(), Error> {
     // Tests ingesting a single point and specifying a valid configuration for
     // a custom dimension partition key with optional enforcement.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "dimension");
     env::set_var("custom_partition_key_dimension", "nomatch");
     env::set_var("enforce_custom_partition_key", "false");
@@ -1306,7 +1350,8 @@ async fn test_mtmm_custom_dimension_partition_key_required_enforcement_accepted(
 ) -> Result<(), Error> {
     // Tests ingesting a single point and specifying a valid configuration for
     // a custom dimension partition key with required enforcement and a successful ingestion.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "dimension");
     env::set_var("custom_partition_key_dimension", "tag1");
     env::set_var("enforce_custom_partition_key", "true");
@@ -1347,7 +1392,8 @@ async fn test_mtmm_custom_dimension_partition_key_required_enforcement_rejected(
 ) -> Result<(), Error> {
     // Tests ingesting a single point and specifying a valid configuration for
     // a custom dimension partition key with required enforcement and an unsuccessful ingestion.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "dimension");
     env::set_var("custom_partition_key_dimension", "nomatch");
     env::set_var("enforce_custom_partition_key", "true");
@@ -1386,7 +1432,8 @@ async fn test_mtmm_custom_dimension_partition_key_required_enforcement_rejected(
 async fn test_mtmm_custom_dimension_partition_key_no_dimension() -> Result<(), Error> {
     // Tests ingesting a single point and specifying a configuration for
     // a custom dimension partition key without a dimension specified.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "dimension");
     env::remove_var("custom_partition_key_dimension");
     env::set_var("enforce_custom_partition_key", "false");
@@ -1425,7 +1472,8 @@ async fn test_mtmm_custom_dimension_partition_key_no_dimension() -> Result<(), E
 async fn test_mtmm_custom_dimension_partition_key_no_enforcement() -> Result<(), Error> {
     // Tests ingesting a single point and specifying a configuration for
     // a custom dimension partition key without an enforcement configuration specified.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "dimension");
     env::set_var("custom_partition_key_dimension", "tag1");
     env::remove_var("enforce_custom_partition_key");
@@ -1464,7 +1512,8 @@ async fn test_mtmm_custom_dimension_partition_key_no_enforcement() -> Result<(),
 async fn test_mtmm_custom_measure_partition_key() -> Result<(), Error> {
     // Tests ingesting a single point and specifying a valid configuration for
     // a custom measure partition key.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "measure");
     env::remove_var("custom_partition_key_dimension");
     env::remove_var("enforce_custom_partition_key");
@@ -1504,7 +1553,8 @@ async fn test_mtmm_custom_measure_partition_key() -> Result<(), Error> {
 async fn test_mtmm_custom_measure_partition_key_with_dimension() -> Result<(), Error> {
     // Tests ingesting a single point and specifying a valid configuration for
     // a custom measure partition key with a dimension specified. The dimension should be ignored.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "measure");
     env::set_var("custom_partition_key_dimension", "should_be_ignored");
     env::remove_var("enforce_custom_partition_key");
@@ -1545,7 +1595,8 @@ async fn test_mtmm_custom_measure_partition_key_with_enforcement() -> Result<(),
     // Tests ingesting a single point and specifying a valid configuration for
     // a custom measure partition key with an enforcement configuration specified.
     // The enforcement configuration should be ignored.
-    set_environment_variables();
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     env::set_var("custom_partition_key_type", "measure");
     env::remove_var("custom_partition_key_dimension");
     env::set_var("enforce_custom_partition_key", "false");
@@ -1574,6 +1625,103 @@ async fn test_mtmm_custom_measure_partition_key_with_enforcement() -> Result<(),
     println!("Response: {:?}", response);
 
     let mut cleanup_batch = CleanupBatch::new(DATABASE_NAME.to_string(), vec![lp_measurement_name]);
+    cleanup_batch.cleanup(&client).await;
+
+    assert!(response.is_ok());
+    assert!(response?["statusCode"] == 200);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stmm_basic() -> Result<(), Error> {
+    // Tests ingesting a single point.
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::SingleTableMultiMeasure);
+    let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
+        .await
+        .expect("Failed to get client");
+    let client = Arc::new(client);
+
+    let lp_measurement_name = String::from("readings");
+
+    let point = format!(
+        "{},tag1={} field1={}i {}\n",
+        lp_measurement_name,
+        random_string(9),
+        random_number(0, 100001),
+        chrono::offset::Utc::now().timestamp_millis()
+    );
+
+    let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": point }),
+        Context::default(),
+    );
+
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    println!("Response {:?}", response);
+
+    let mut cleanup_batch = CleanupBatch::new(DATABASE_NAME.to_string(), vec![lp_measurement_name]);
+    cleanup_batch.cleanup(&client).await;
+
+    assert!(response.is_ok());
+    assert!(response?["statusCode"] == 200);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stmm_varying_metrics() -> Result<(), Error> {
+    // Tests ingesting a batch with 100 measurements.
+    set_base_environment_variables();
+    set_table_mapping_env_variables(SchemaType::SingleTableMultiMeasure);
+    let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
+        .await
+        .expect("Failed to get client");
+    let client = Arc::new(client);
+
+    let mut table_names_to_delete = Vec::<String>::new();
+
+    let lp_readings_measurement_name = String::from("readings");
+    let mut lp_batch = String::new();
+    for i in 0..10 {
+        let lp_readings_measurement_name = format!("{lp_readings_measurement_name}{i}").to_string();
+        table_names_to_delete.push(lp_readings_measurement_name.clone());
+
+        let point = format!(
+            "{},tag1={} field1={}i {}\n",
+            lp_readings_measurement_name,
+            random_string(9),
+            random_number(0, 100001),
+            chrono::Utc::now().timestamp_millis()
+        );
+        lp_batch.push_str(&point);
+    }
+
+    let lp_velocity_measurement_name = String::from("velocity");
+    for i in 0..10 {
+        let lp_velocity_measurement_name = format!("{lp_velocity_measurement_name}{i}").to_string();
+        table_names_to_delete.push(lp_readings_measurement_name.clone());
+
+        let point = format!(
+            "{},tag1={} field1={}i {}\n",
+            lp_velocity_measurement_name,
+            random_string(9),
+            random_number(0, 100001),
+            chrono::Utc::now().timestamp_millis()
+        );
+        lp_batch.push_str(&point);
+    }
+
+    let query_parameters = HashMap::from([("precision".to_string(), "ms".to_string())]);
+    let request = LambdaEvent::<Value>::new(
+        json!({ "queryStringParameters": query_parameters, "body": lp_batch }),
+        Context::default(),
+    );
+
+    let response = influxdb_timestream_connector::lambda_handler(&client, request).await;
+    println!("Response {:?}", response);
+
+    let mut cleanup_batch = CleanupBatch::new(DATABASE_NAME.to_string(), table_names_to_delete);
     cleanup_batch.cleanup(&client).await;
 
     assert!(response.is_ok());


### PR DESCRIPTION
Added support for single table mapping with multi-measure records. When mapping type is set to `single-table`, the `measure_name` in the Timestream record is set to the line protocol metric name. The ingestion table is determined by the `single_table_name` environment variable. Mapping aligns with Telegraf to ensure ingestion options have the same mapping outcome for Timestream records.

**Mapping example**:

#### Line Protocol Point

```
cpu_load_short,host=server01,region=us-west value=0.64,average=1.24 1725059274
weather,location=us-midwest,season=summer temperature=82.0,humidity=71.0 1706480990
```

#### Resulting influxdb-measures Timestream for LiveAnalytics Table

| host     | region  | location | season | measure_name     | time                          | value | average | temperature | humidity |
|----------|---------|------------------|-------------------------------|-------|---------|------------|--------|-------------|----------|
| server01 | us-west |   | | cpu_load_short | 2024-08-30 23:07:54.000000000 | 0.64  | 1.24    |            |          |
|          |        | us-midwest | summer  | weather          | 2024-01-22 26:07:33.000000000 |   |     |  82.0        | 71.0     |

Example Telegraf configuration to ensure mapping is aligned:

```
[global_tags]
  microservice = "web"
  region = "us-east-1"

[agent]
  interval = "10s"
  round_interval = true
  metric_batch_size = 1000
  metric_buffer_limit = 10000
  collection_jitter = "0s"
  flush_interval = "10s"
  flush_jitter = "0s"
  precision = ""
  hostname = ""
  omit_hostname = false

[[inputs.cpu]]
  percpu = true
  totalcpu = true
  collect_cpu_time = false
  report_active = false

[[inputs.mem]]

[[inputs.disk]]
  ignore_fs = ["tmpfs", "devtmpfs"]

[[inputs.system]]
[[outputs.timestream]]
  region = "us-east-1"
  database_name = "temptesttelegraf"
  describe_database_on_start = true
  mapping_mode = "single-table"
  create_table_if_not_exists = true
  create_table_magnetic_store_retention_period_in_days = 365
  create_table_memory_store_retention_period_in_hours = 24
  use_multi_measure_records = true

  ## Specifies the measure_name to use when sending multi-measure records.
  ## NOTE: This property is valid when use_multi_measure_records=true and mapping_mode=multi-table
  # measure_name_for_multi_measure_records = "telegraf_measure"

  ## Specifies the name of the table to write data into
  ## NOTE: This property is valid when mapping_mode=single-table.
  single_table_name = "telegraf_measures"

  ## Specifies the name of dimension when all of the data is being stored in a single table
  ## and the measurement name is transformed into the dimension value
  ## (see Mapping data from Influx to Timestream for details)
  ## NOTE: This property is valid when mapping_mode=single-table.
  single_table_dimension_name_for_telegraf_measurement_name = "namespace"
  max_write_go_routines = 25
```