### PR TITLE
Add support for returning gzip compressed responses

### DIFF
--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -623,3 +623,7 @@ In order to ingest to Timestream for LiveAnalytics, every line protocol point mu
 ### Query String Parameters
 
 The connector expects query string parameters to be included as `queryParameters` or `queryStringParameters` in requests.
+
+### Lack of Local Gzip Support
+
+The connector, when deployed as part of a CloudFormation stack, supports requests sent with Content-Type and Accept-Encoding headers set to `gzip`. However, when run locally with either Cargo Lambda or the SAM CLI, gzip compression is not supported.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/records_builder.rs
@@ -1,5 +1,5 @@
 use crate::metric::Metric;
-use crate::timestream_utils::{DIMENSION_PARTITION_KEY_TYPE, MEASURE_PARTITION_KEY_TYPE};
+use crate::timestream_utils::DIMENSION_PARTITION_KEY_TYPE;
 use anyhow::{anyhow, Error};
 use aws_sdk_timestreamwrite::types as timestream_types;
 use std::{collections::HashMap, fmt::Debug};
@@ -141,14 +141,6 @@ pub fn validate_env_variables() -> Result<(), Error> {
     let custom_partition_key_type = std::env::var("custom_partition_key_type");
 
     if let Ok(custom_partition_key_type) = custom_partition_key_type {
-        if custom_partition_key_type != DIMENSION_PARTITION_KEY_TYPE
-            && custom_partition_key_type != MEASURE_PARTITION_KEY_TYPE
-        {
-            return Err(anyhow!(
-                format!("custom_partition_key_type can only be {DIMENSION_PARTITION_KEY_TYPE} or {MEASURE_PARTITION_KEY_TYPE}")
-            ));
-        }
-
         // Check required environment variables for when custom partition key type is "dimension." If it is "measure,"
         // no other environment variables are necessary.
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -128,6 +128,7 @@ Resources:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: !Sub "${RestApiGatewayName}-${AWS::StackName}"
+      MinimumCompressionSize: 0
 
   ApiResource:
     Type: AWS::ApiGateway::Resource

--- a/integrations/influxdb_connector/sample-influxdb-clients/go/line-protocol-client-demo.go
+++ b/integrations/influxdb_connector/sample-influxdb-clients/go/line-protocol-client-demo.go
@@ -30,6 +30,7 @@ var(
     endpoint string
     dataset string
     precision string
+    useGzip bool
 )
 
 func main() {
@@ -38,10 +39,12 @@ func main() {
     flag.StringVar(&endpoint, "endpoint", "http://localhost:9000", "Endpoint for InfluxDB Timestream Connector")
     flag.StringVar(&dataset, "dataset", "../data/bird-migration.line", "Line protocol dataset being ingested")
     flag.StringVar(&precision, "precision", "ns", "Precision for line protocol: nanoseconds=ns, milliseconds=ms, microseconds=us, seconds=s")
+    flag.BoolVar(&useGzip, "gzip", false, "Whether to compress requests with gzip")
     flag.Parse()
 
     opts := influxdb2.DefaultOptions()
     opts.HTTPOptions().SetHTTPDoer(&SigV4HeaderSetter{RequestDoer: opts.HTTPClient(),})
+    opts.WriteOptions().SetUseGZip(useGzip)
 
     switch {
     case precision == "ns":


### PR DESCRIPTION
Changes:
- If requests set `"Accept-Encoding": "gzip"`, then the REST API Gateway will use gzip compression for responses.
- To support `sam local start-api`, which uses an empty string for `"AWS::NoValue"`, a `custom_partition_key_type` value that does not match `dimension` or `measure` will be ignored, instead of causing an `Err`.
- The Go sample client has been updated to support sending requests with gzip compression, configured using the new `--gzip` flag.

- [x] Unit tests passed.
- [x] Integration tests passed.