### PR TITLE
Defining Least-privilege Lambda Invocation Permissions for the InfluxDB Timestream Connector

### DIFF
--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -403,6 +403,8 @@ Replace all items listed below in the IAM policy with values from your AWS accou
 - *{region}* &mdash; The AWS region where the InfluxDB Timestream Connector is deployed.
 - *{account-id}* &mdash; The AWS account ID used to deploy the connector.
 - *{api-id}* &mdash; The API ID for the deployed REST API Gateway.
+- *{api-stage-name}* &mdash; The stage name for the deployed REST API Gateway.
+
 
 ```json
 {
@@ -411,7 +413,7 @@ Replace all items listed below in the IAM policy with values from your AWS accou
         {
             "Effect": "Allow",
             "Action": "execute-api:Invoke",
-            "Resource": "arn:aws:execute-api:{region}:{account-id}:{api-id}/dev/POST/api/v2/write"
+            "Resource": "arn:aws:execute-api:{region}:{account-id}:{api-id}/{api-stage-name}/POST/api/v2/write"
         }
     ]
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -396,7 +396,7 @@ Replace all items listed below in the IAM policy with values from your AWS accou
 
 ### IAM Execution Permissions
 
-The following is the least privileged IAM permissions required for invoking the deployed InfluxDB Timestream connector REST API Gateway.
+The following are the least privileged IAM permissions required for invoking the deployed InfluxDB Timestream connector REST API Gateway.
 
 Replace all items listed below in the IAM policy with values from your AWS account:
 
@@ -421,7 +421,7 @@ Replace all items listed below in the IAM policy with values from your AWS accou
 
 ### IAM Lambda Permissions
 
-The following is the IAM permissions required for the InfluxDB Timestream Connector Lambda function to ingest data to Timestream for LiveAnalytics. This IAM policy is attached to the Lambda function when deployed with the CloudFormation template. Additional policies are also attached for logging and DLQ functionalities. For the complete list of IAM permissions attached to the Lambda function, see the [template.yml](./template.yml).
+The following are the IAM permissions required for the InfluxDB Timestream Connector Lambda function to ingest data into Timestream for LiveAnalytics. This IAM policy is attached to the Lambda function when deployed with the CloudFormation template. Additional policies are also attached for logging and DLQ functionalities. For the complete list of IAM permissions attached to the Lambda function, see the [template.yml](./template.yml).
 
 All items listed below in the IAM policy are associated to the equivalent values from your AWS account:
 

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -260,6 +260,11 @@ The following permissions are the least-privilege permissions for deploying and 
 
 The following is the least-privilege IAM permissions for deploying the connector.
 
+Replace all items listed below in the IAM policy with values from your AWS account:
+
+- *{region}* &mdash; The AWS region where the InfluxDB Timestream Connector is deployed.
+- *{account-id}* &mdash; The AWS account ID used to deploy the connector.
+
 ```json
 {
     "Version": "2012-10-17",
@@ -391,7 +396,13 @@ The following is the least-privilege IAM permissions for deploying the connector
 
 ### IAM Execution Permissions
 
-The following is the least privileged IAM permissions for executing the connector.
+The following is the least privileged IAM permissions required for invoking the deployed InfluxDB Timestream connector REST API Gateway.
+
+Replace all items listed below in the IAM policy with values from your AWS account:
+
+- *{region}* &mdash; The AWS region where the InfluxDB Timestream Connector is deployed.
+- *{account-id}* &mdash; The AWS account ID used to deploy the connector.
+- *{api-id}* &mdash; The API ID for the deployed REST API Gateway.
 
 ```json
 {
@@ -399,28 +410,8 @@ The following is the least privileged IAM permissions for executing the connecto
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": [
-                "timestream:WriteRecords",
-                "timestream:Select",
-                "timestream:DescribeTable",
-				"timestream:CreateTable"
-            ],
-            "Resource": "arn:aws:timestream:{region}:{account-id}:database/influxdb-line-protocol/table/*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "timestream:DescribeEndpoints"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "timestream:DescribeDatabase",
-				"timestream:CreateDatabase"
-            ],
-            "Resource": "arn:aws:timestream:{region}:{account-id}:database/influxdb-line-protocol"
+            "Action": "execute-api:Invoke",
+            "Resource": "arn:aws:execute-api:{region}:{account-id}:{api-id}/dev/POST/api/v2/write"
         }
     ]
 }

--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -419,6 +419,48 @@ Replace all items listed below in the IAM policy with values from your AWS accou
 }
 ```
 
+### IAM Lambda Permissions
+
+The following is the IAM permissions required for the InfluxDB Timestream Connector Lambda function to ingest data to Timestream for LiveAnalytics. This IAM policy is attached to the Lambda function when deployed with the CloudFormation template. Additional policies are also attached for logging and DLQ functionalities. For the complete list of IAM permissions attached to the Lambda function, see the [template.yml](./template.yml).
+
+All items listed below in the IAM policy are associated to the equivalent values from your AWS account:
+
+- *{region}* &mdash; The AWS region where the InfluxDB Timestream Connector is deployed.
+- *{account-id}* &mdash; The AWS account ID used to deploy the connector.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:WriteRecords",
+                "timestream:Select",
+                "timestream:DescribeTable",
+                "timestream:CreateTable"
+            ],
+            "Resource": "arn:aws:timestream:{region}:{account-id}:database/influxdb-line-protocol/table/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:DescribeEndpoints"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:DescribeDatabase",
+                "timestream:CreateDatabase"
+            ],
+            "Resource": "arn:aws:timestream:{region}:{account-id}:database/influxdb-line-protocol"
+        }
+    ]
+}
+```
+
 ## Example Application with Go Client
 
 A demo Go client application is available under `sample-code/aws-timestream/sample-influxdb-clients/go/line-protocol-client-demo.go` that sends line protocol data to a local or deployed instance of the connector. A line protocol sample dataset is included in `sample-code/aws-timestream/sample-influxdb-clients/data/bird-migration.line`, which the demo application uses for ingestion.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -566,6 +566,19 @@ Outputs:
   Endpoint:
     Description: The endpoint for the REST API Gateway.
     Value: !Sub https://${RestApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${RestApiGatewayStageName}
+  ExecutionPolicy:
+    Description: The IAM policy permissions required for invoking the InfluxDB Timestream Connector.
+    Value: !Sub |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Action": "execute-api:Invoke",
+                  "Resource": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApiGateway}/dev/POST/api/v2/write"
+              }
+          ]
+      }
   LambdaDeadLetterQueueName:
     Description: The name of the dead letter queue used by the Lambda function.
     Condition: IsAsyncEnabled

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -575,7 +575,7 @@ Outputs:
               {
                   "Effect": "Allow",
                   "Action": "execute-api:Invoke",
-                  "Resource": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApiGateway}/dev/POST/api/v2/write"
+                  "Resource": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApiGateway}/${RestApiGatewayStageName}/POST/api/v2/write"
               }
           ]
       }


### PR DESCRIPTION
Issue #, if available:

N/A.

Description of changes:

Documentation has been added covering what IAM permissions are required when invoking the deployed InfluxDB Timestream Connector Lambda function. The permissions required to invoke the Lambda function by way of REST API Gateway are now output when deploying through the SAM template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
