### PR TITLE
Adding support for AWS KMS key and tags in database and table creation

### DIFF
--- a/integrations/influxdb_connector/influxdb-timestream-connector/README.md
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/README.md
@@ -95,6 +95,9 @@ The following parameters are available when deploying the connector as part of a
 | `CustomPartitionKeyDimension` |  The dimension to use as the partition key. This parameter is required if the CustomPartitionKeyType parameter is set to `dimension`. | |
 | `CustomPartitionKeyType` | The type of custom partition key to use. Valid options are `dimension` or `measure`. The `dimension` option requires the CustomPartitionKeyDimension parameter to also be set. If this parameter is not provided, newly-created tables will use default partitioning and none of the parameters relating to custom partition keys will be used. | |
 | `DatabaseName`  | The name of the database to use for ingestion. | `influxdb-line-protocol` |
+| `KmsKey`  | AWS KMS key to encrypt the database on creation. If the KMS key is not specified, the database will be encrypted with a Timestream managed KMS key created under your account. | |
+| `DatabaseTags`  | A comma-separated string of key-value pairs to label the database. For example, `example_key1=example_value1,example_key2=example_value2` | |
+| `TableTags`  | A comma-separated string of key-value pairs to label the table(s). For example, `example_key1=example_value1,example_key2=example_value2` | |
 | `EnableDatabaseCreation` | Whether to allow database creation upon ingestion of records. | `true` |
 | `EnableTableCreation` | Whether to allow table creation upon ingestion of records. When using multi-table multi measure schema, each unique line protocol measurement in a request will result in the creation of a new table with the same name as the measurement. | `true` |
 | `EnableMagStoreWrites` | if `EnableTableCreation` is `true`, whether to enable mag store writes. | `true` |
@@ -181,6 +184,9 @@ The connector can be run locally using [Cargo Lambda](https://www.cargo-lambda.i
 4. Configure the following environment variables:
     - `region` string: the AWS region to use. Defaults to `us-east-1`.
     - `database_name` string: the Timestream for LiveAnalytics database name to use. Defaults to `influxdb-line-protocol`.
+    - `kms_key_id` string: AWS KMS key to encrypt the database on creation.
+    - `database_tags` string: A comma-separated string of key-value pairs to label the database.
+    - `table_tags` string: A comma-separated string of key-value pairs to label the table(s).
     - `measure_name_for_multi_measure_records` string: the value to use in records as the measure name. Defaults to `influxdb-measure`.
     - `table_mapping` string: determines whether to ingest all data to a single table or multiple tables.
     - `single_table_name` string: when table mapping is set to `single-table`, this value determines the table name.

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/lib.rs
@@ -67,13 +67,24 @@ async fn handle_ingestion(
     let database_name = std::env::var("database_name")?;
     let database_name = Arc::new(database_name);
 
+    let kms_key_id = std::env::var("kms_key_id").ok();
+
+    let database_tags = match std::env::var("database_tags") {
+        Ok(database_tags_str) => match parse_tags_from_str(&database_tags_str) {
+            Ok(tags) => Some(tags),
+            Err(_) => None,
+        },
+        Err(_) => None,
+    };
+
+
     if let Ok(true) = std::env::var("enable_database_creation").map(env_var_to_bool) {
         match database_exists(client, &database_name).await {
             Ok(true) => (),
             Ok(false) => {
                 if database_creation_enabled()? {
                     thread::sleep(time::Duration::from_secs(TIMESTREAM_API_WAIT_SECONDS));
-                    create_database(client, &database_name).await?;
+                    create_database(client, &database_name, kms_key_id.as_deref(), database_tags).await?;
                 } else {
                     return Err(anyhow!(
                         "Database {} does not exist and database creation is not enabled",
@@ -148,11 +159,18 @@ pub async fn create_table_if_non_existent(
     database_name: &Arc<String>,
     table_name: &str,
 ) -> Result<(), Error> {
+    let table_tags = match std::env::var("table_tags") {
+        Ok(table_tags_str) => match parse_tags_from_str(&table_tags_str) {
+            Ok(tags) => Some(tags),
+            Err(_) => None,
+        },
+        Err(_) => None,
+    };
     match table_exists(client, database_name, table_name).await {
         Ok(true) => (),
         Ok(false) => {
             thread::sleep(time::Duration::from_secs(TIMESTREAM_API_WAIT_SECONDS));
-            create_table(client, database_name, table_name, get_table_config()?).await?
+            create_table(client, database_name, table_name, get_table_config()?, table_tags).await?
         }
         Err(error) => info!("error checking table exists: {:?}", error),
     }
@@ -315,3 +333,106 @@ pub fn test_get_precision_incorrect_precision_key() -> Result<(), Error> {
     assert!(get_precision(&fake_event_value).is_none());
     Ok(())
 }
+
+#[test]
+pub fn test_parse_tags_from_str_empty_string() -> Result<(), Error> {
+    let tags_str = "";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert!(tags.is_empty());
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_whitespace_only() -> Result<(), Error> {
+    let tags_str = "   ";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert!(tags.is_empty());
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_tag_with_no_value() -> Result<(), Error> {
+    let tags_str = "key1";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].key, "key1");
+    assert_eq!(tags[0].value, "");
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_multiple_tags() -> Result<(), Error> {
+    let tags_str = "key1=value1, key2=value2, key3=value3";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert_eq!(tags.len(), 3);
+    assert_eq!(tags[0].key, "key1");
+    assert_eq!(tags[0].value, "value1");
+    assert_eq!(tags[1].key, "key2");
+    assert_eq!(tags[1].value, "value2");
+    assert_eq!(tags[2].key, "key3");
+    assert_eq!(tags[2].value, "value3");
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_extra_commas() -> Result<(), Error> {
+    let tags_str = "key1=value1, , key2=value2,";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert_eq!(tags.len(), 2);
+    assert_eq!(tags[0].key, "key1");
+    assert_eq!(tags[0].value, "value1");
+    assert_eq!(tags[1].key, "key2");
+    assert_eq!(tags[1].value, "value2");
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_multiple_equals() -> Result<(), Error> {
+    let tags_str = "key1=value=with=equals";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].key, "key1");
+    assert_eq!(tags[0].value, "value=with=equals");
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_trimming_whitespace() -> Result<(), Error> {
+    let tags_str = "  key1  =  value1  ,   key2=   value2  ";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert_eq!(tags.len(), 2);
+    assert_eq!(tags[0].key, "key1");
+    assert_eq!(tags[0].value, "value1");
+    assert_eq!(tags[1].key, "key2");
+    assert_eq!(tags[1].value, "value2");
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_tag_with_empty_value_explicit() -> Result<(), Error> {
+    let tags_str = "key1=,key2=2,key3";
+    let tags = parse_tags_from_str(tags_str)?;
+    assert_eq!(tags.len(), 3);
+    assert_eq!(tags[0].key, "key1");
+    assert_eq!(tags[0].value, "");
+    assert_eq!(tags[1].key, "key2");
+    assert_eq!(tags[1].value, "2");
+    assert_eq!(tags[2].key, "key3");
+    assert_eq!(tags[2].value, "");
+    Ok(())
+}
+
+#[test]
+pub fn test_parse_tags_from_str_error_empty_key() {
+    let tags_str = "=value";
+    let err = parse_tags_from_str(tags_str).unwrap_err();
+    assert!(err.to_string().contains("Tag key must not be empty"));
+}
+
+#[test]
+pub fn test_parse_tags_from_str_error_only_equals() {
+    let tags_str = "   =   ";
+    let err = parse_tags_from_str(tags_str).unwrap_err();
+    assert!(err.to_string().contains("Tag key must not be empty"));
+}
+

--- a/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/src/timestream_utils.rs
@@ -50,16 +50,37 @@ pub async fn get_connection(
 pub async fn create_database(
     client: &Arc<timestream_write::Client>,
     database_name: &str,
+    kms_key_id: Option<&str>,
+    tags: Option<Vec<timestream_write::types::Tag>>,
 ) -> Result<(), timestream_write::Error> {
     // Create a new Timestream database
+    info!("Creating new database: {}", database_name);
 
-    info!("Creating new database {}", database_name);
-    client
+    let mut create_db_builder = client
         .create_database()
-        .set_database_name(Some(database_name.to_owned()))
-        .send()
-        .await?;
+        .set_database_name(Some(database_name.to_owned()));
 
+    if let Some(kms) = kms_key_id.filter(|s| !s.is_empty()) {
+        info!("Using KMS Key ID: {}", kms);
+        create_db_builder = create_db_builder.set_kms_key_id(Some(kms.to_owned()));
+    } else {
+        info!("No KMS Key ID provided. Using default Timestream-managed KMS key.");
+    }
+
+    if let Some(tags_vec) = tags {
+        if !tags_vec.is_empty() {
+            info!("Adding {} tags to the database.", tags_vec.len());
+            create_db_builder = create_db_builder.set_tags(Some(tags_vec));
+        } else {
+            info!("Empty tags vector provided. Skipping tag assignment.");
+        }
+    } else {
+        info!("No tags provided for the database.");
+    }
+
+    create_db_builder.send().await?;
+
+    info!("Database '{}' created successfully.", database_name);
     Ok(())
 }
 
@@ -69,13 +90,14 @@ pub async fn create_table(
     database_name: &str,
     table_name: &str,
     table_config: TableConfig,
+    tags: Option<Vec<timestream_write::types::Tag>>,
 ) -> Result<(), timestream_write::Error> {
     // Create a new Timestream table
-
     info!(
         "Creating new table {} for database {}",
         table_name, database_name
     );
+
     let retention_properties = timestream_write::types::RetentionProperties::builder()
         .set_magnetic_store_retention_period_in_days(Some(table_config.mag_store_retention_period))
         .set_memory_store_retention_period_in_hours(Some(table_config.mem_store_retention_period))
@@ -103,18 +125,31 @@ pub async fn create_table(
         None
     };
 
-    client
+    let mut create_table_builder = client
         .create_table()
         .set_schema(table_schema)
         .set_table_name(Some(table_name.to_owned()))
         .set_database_name(Some(database_name.to_owned()))
         .set_retention_properties(Some(retention_properties))
-        .set_magnetic_store_write_properties(Some(magnetic_store_properties))
-        .send()
-        .await?;
+        .set_magnetic_store_write_properties(Some(magnetic_store_properties));
 
+    if let Some(tags_vec) = tags {
+        if !tags_vec.is_empty() {
+            info!("Adding {} tags to the table.", tags_vec.len());
+            create_table_builder = create_table_builder.set_tags(Some(tags_vec));
+        } else {
+            info!("Empty tags vector provided. Skipping tag assignment.");
+        }
+    } else {
+        info!("No tags provided for the table.");
+    }
+
+    create_table_builder.send().await?;
+
+    info!("Table '{}' created successfully in database '{}'.", table_name, database_name);
     Ok(())
 }
+
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 pub async fn table_exists(
@@ -165,6 +200,41 @@ pub async fn database_exists(
         },
     }
 }
+
+#[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
+pub fn parse_tags_from_str(tags_str: &str) -> Result<Vec<timestream_write::types::Tag>, Error> {
+    let mut tags = Vec::new();
+
+    for tag in tags_str.split(',') {
+        let tag = tag.trim();
+        if tag.is_empty() {
+            continue;
+        }
+        let mut parts = tag.splitn(2, '=');
+        let key = parts
+            .next()
+            .ok_or_else(|| anyhow!("Missing key in tag '{}'", tag))?
+            .trim();
+
+        // ensure key is not empty
+        if key.is_empty() {
+            return Err(anyhow!("Tag key must not be empty in tag '{}'", tag));
+        }
+        let key = key.to_string();
+
+        // get the value if present; if it's missing or empty, use an empty string.
+        let value = parts.next().map(|v| v.trim()).unwrap_or("");
+
+        let tag_instance = timestream_write::types::Tag::builder()
+            .key(key)
+            .value(value.to_string())
+            .build()?;
+        tags.push(tag_instance);
+    }
+
+    Ok(tags)
+}
+
 
 #[tracing::instrument(skip_all, level = tracing::Level::TRACE)]
 pub fn get_table_config() -> Result<TableConfig, Error> {

--- a/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/template.yml
@@ -28,6 +28,18 @@ Parameters:
     Type: String
     Default: influxdb-line-protocol
     Description: The Timestream for LiveAnalytics database name to use.
+  KmsKeyId:
+    Type: String
+    Description: AWS KMS key for the database. If the KMS key is not specified, the database will be encrypted with a Timestream managed KMS key located in your account.
+    Default: ''
+  DatabaseTags:
+    Type: String
+    Description: A comma-separated string of key-value pairs to label the database. For example, `example_key1=example_value1,example_key2=example_value2`
+    Default: ''
+  TableTags:
+    Type: String
+    Description: A comma-separated string of key-value pairs to label the table(s). For example, `example_key1=example_value1,example_key2=example_value2`
+    Default: ''
   MeasureNameForMultiMeasureRecords:
     Type: String
     Default: influxdb-measure
@@ -504,6 +516,7 @@ Resources:
                 - timestream:DescribeTable
                 - timestream:WriteRecords
                 - timestream:CreateTable
+                - timestream:TagResource
                 Effect: Allow
                 Resource: !Sub arn:aws:timestream:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}/table/*
         - PolicyName: LambdaTimestreamDatabasePolicy
@@ -513,8 +526,18 @@ Resources:
               - Action:
                 - timestream:DescribeDatabase
                 - timestream:CreateDatabase
+                - timestream:TagResource
                 Effect: Allow
                 Resource: !Sub arn:aws:timestream:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}
+        - PolicyName: LambdaKMSPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                - kms:DescribeKey
+                - kms:CreateGrant
+                Effect: Allow
+                Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${KmsKeyId}
 
   LambdaFunction:
     Type: AWS::Serverless::Function
@@ -547,6 +570,9 @@ Resources:
           custom_partition_key_type: !If [CustomPartitionKeyTypeProvided, !Ref CustomPartitionKeyType, !Ref "AWS::NoValue"]
           custom_partition_key_dimension: !If [CustomPartitionKeyDimensionProvided, !Ref CustomPartitionKeyDimension, !Ref "AWS::NoValue"]
           database_name: !Ref DatabaseName
+          kms_key_id: !Ref KmsKeyId
+          database_tags: !Ref DatabaseTags
+          table_tags: !Ref TableTags
           measure_name_for_multi_measure_records: !Ref MeasureNameForMultiMeasureRecords
           table_mapping: !Ref TableMapping
           single_table_name: !Ref SingleTableName

--- a/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
+++ b/integrations/influxdb_connector/influxdb-timestream-connector/tests/integration_test.rs
@@ -149,7 +149,9 @@ async fn test_mtmm_create_database() -> Result<(), Error> {
     set_base_environment_variables();
     set_table_mapping_env_variables(SchemaType::MultiTableMultiMeasure);
     let test_create_database_name = "test_create_database_influxdb_timestream_connector_integ";
+    let database_tags = "environment=test";
     env::set_var("database_name", test_create_database_name);
+    env::set_var("database_tags", database_tags);
     let client = influxdb_timestream_connector::timestream_utils::get_connection(REGION)
         .await
         .expect("Failed to get client");


### PR DESCRIPTION
Added support for supplying CMK (AWS KMS) and tags in `create_database` and `create_table`