### PR TITLE
Add migration validation script 

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/Dockerfile
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.13-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/Makefile
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/Makefile
@@ -18,3 +18,19 @@ influx_only:
 		-it \
 		validator \
 		bash -c "python validator.py --influx-only"
+skip_wal: 
+	docker run --rm \
+		-v $(PWD):/app \
+		-v $(HOME)/.aws:/root/.aws:ro \
+		-e AWS_PROFILE=default \
+		-it \
+		validator \
+		bash -c "python validator.py --skip-wal-check"
+track_influx: 
+	docker run --rm \
+		-v $(PWD):/app \
+		-v $(HOME)/.aws:/root/.aws:ro \
+		-e AWS_PROFILE=default \
+		-it \
+		validator \
+		bash -c "python validator.py --influx-only --skip-wal-check"

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/Makefile
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/Makefile
@@ -1,0 +1,20 @@
+.PHONY: all build validate 
+all: build validate 
+build: 
+	docker build . -t validator 
+validate: 
+	docker run --rm \
+		-v $(PWD):/app \
+		-v $(HOME)/.aws:/root/.aws:ro \
+		-e AWS_PROFILE=default \
+		-it \
+		validator \
+		bash -c "python validator.py"
+influx_only: 
+	docker run --rm \
+		-v $(PWD):/app \
+		-v $(HOME)/.aws:/root/.aws:ro \
+		-e AWS_PROFILE=default \
+		-it \
+		validator \
+		bash -c "python validator.py --influx-only"

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/README.md
@@ -83,6 +83,22 @@ All settings can be supplied as CLI flags **or** environment variables. See [exa
 - `--skip-wal-check` / `SKIP_WAL_CHECK` – Skip WAL‑flush wait *(default: false)*  
 - `--influx-only` / `INFLUX_ONLY` – Skip source query; return Influx count only *(default: false)*  
 
+#### With Docker
+
+For full validation:
+```bash
+make validate
+```
+
+To query only InfluxDB:
+```bash
+make influx_only
+```
+
+To track ingestion (skips WAL check & queries only InfluxDB)
+```bash
+make track_influx
+```
 
 ## Use Cases
 
@@ -99,16 +115,24 @@ All settings can be supplied as CLI flags **or** environment variables. See [exa
 
 ### Success Output
 ```
-Starting validation ... (engine = athena)
+--------------------
+Starting validation
+--------------------
+
+Polling https://xxx-yyy.timestream-influxdb.us-west-2.on.aws:8086/metrics to wait for WAL to complete flushing ... 
+
+2025-05-06 20:45:59  WAL empty on all shards — ready for validation.
+
+Starting validation ...
 
 --- InfluxDB ---
-Total LP points in bucket.cpu (begin – now): 124761600
+Total LP points in bucket-big.cpu (2024-01-01T00:00:00Z – 2025-02-01T00:00:00Z): 975661
 
 --- Athena ---
-Total records in default.cpu_usage_smol (begin – now): 124761600
+Total records in default.cpu_usage (2024-01-01T00:00:00Z – 2025-02-01T00:00:00Z): 975661
 
-⏱ Athena query time: 23.31 s
-⏱ InfluxDB query time:   1.01 s
+⏱ Athena query time: 8.62 s
+⏱ InfluxDB query time:   0.18 s
 
 --------- Migration Results ---------
 
@@ -117,7 +141,15 @@ Total records in default.cpu_usage_smol (begin – now): 124761600
 
 ### Mismatch Output
 ```
-Starting validation ... (engine = athena)
+--------------------
+Starting validation
+--------------------
+
+Polling https://zzz-yyy.timestream-influxdb.us-west-2.on.aws:8086/metrics to wait for WAL to complete flushing ... 
+
+2025-05-06 20:45:59  WAL empty on all shards — ready for validation.
+
+Starting validation ...
 
 --- InfluxDB ---
 Total LP points in bucket3.cpu (2025-03-01T00:00:00Z – 2025-03-02T00:00:00Z): 10634255

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/README.md
@@ -1,1 +1,145 @@
-# TODO
+# Migration Validation Script
+
+The migration validation script compares **logical row/point counts** between a source table (Amazon Timestream or Amazon Athena) and an InfluxDB bucket measurement, with optional time-range specifications. This tool helps ensure data integrity during migration processes by running parallel queries against both systems and comparing the results.
+
+## Overview
+
+The migration from Timestream for LiveAnalytics to Timestream for InfluxDB involves three stages:
+
+1. Timestream for LiveAnalytics -> Unload to S3 [[#README]](...)
+2. Load from S3 into Athena -> Transform to line protocol (LP)  [[#README]](...)
+3. Download transformed dataset and ingest to Timestream for InfluxDB  [[#README]](...)
+
+The validation script supports queries against either the exported dataset in Athena or the original Timestream database/table. Be aware that querying Timestream directly may lead to inaccurate comparisons if additional data has been written since the export.
+
+The validation script can be run anytime after ingestion has begun. The script first polls InfluxDB's [metrics endpoint](https://docs.influxdata.com/influxdb/v2/reference/internals/metrics/) to wait for the [WAL](https://docs.influxdata.com/influxdb/v2/reference/internals/storage-engine/#write-ahead-log-wal) to flush completely, accounting for post-ingestion [data file merging and de-duplication](https://www.influxdata.com/blog/compactor-hidden-engine-database-performance/#:~:text=loading%20and%20reading.-,Tasks%20of%20post%2Dingestion%20and%20pre%2Dquery,delete%20application%2C%20and%20data%20deduplication.). The script then:
+
+- Executes count‑only queries over an identical time window  
+- Compares results and highlights matches or mismatches  
+- Supports optional schema/tag filtering for [transformed schemas](trevors_readme) 
+- Produces human‑readable timing and result summaries  
+
+
+## Prerequisites
+
+1. Complete the previous migration stages as highlighted above. The validation script will exit early if there are no points ingested to the target InfluxDB instance.
+2. [AWS credentials configured for use with boto3.](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file)
+3. [An InfluxDB access token](https://docs.influxdata.com/influxdb/cloud/admin/tokens/create-token/) for the target Timestream for InfluxDB instance.
+3. One of:
+    - Python 3.8+
+    - Docker
+
+## Installation
+
+1. Create and activate a virtual environment:
+```bash
+python -m venv venv
+source venv/bin/activate
+```
+
+2. Install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+#### With Docker
+
+Build the container with 
+```bash
+make build
+```
+
+## Usage
+
+```
+python validator.py [options]
+```
+
+All settings can be supplied as CLI flags **or** environment variables. See [example.env](example.env) for reference.
+
+### Required arguments
+
+- `--engine` / `ENGINE` – Data source engine: `athena` *(default)* or `timestream`  
+- **Athena‑specific**  
+  - `--athena-db` / `ATHENA_DB` – Database name  
+  - `--athena-table` / `ATHENA_TABLE` – Table name  
+  - `--athena-output` / `ATHENA_OUTPUT` – S3 output path for query results  
+- **Timestream‑specific**  
+  - `--timestream-db` / `TIMESTREAM_DB` – Database name  
+  - `--timestream-table` / `TIMESTREAM_TABLE` – Table name  
+- **InfluxDB**  
+  - `--influx-url` / `INFLUX_URL` – e.g. `https://example.com:8086`  
+  - `--influx-token` / `INFLUX_TOKEN` – API token with read scope  
+  - `--influx-org` / `INFLUX_ORG` – Organisation  
+  - `--influx-bucket` / `INFLUX_BUCKET` – Bucket  
+  - `--influx-measurement` / `INFLUX_MEASUREMENT` – Measurement to validate  
+
+### Optional arguments
+
+- `--schema-tags` / `SCHEMA_TAGS` – Comma‑separated dimension/tag list  
+- `--start-time` / `START_TIME` – Inclusive lower ISO‑8601 bound (e.g., `2024-08-01T00:00:00Z`) 
+- `--end-time` / `END_TIME` – Exclusive upper ISO‑8601 bound (e.g., `2024-08-04T00:00:00Z`) 
+- `--poll-metrics-interval` / `POLL_METRICS_INTERVAL` – Seconds between `/metrics` polls *(default: 30)*  
+- `--skip-wal-check` / `SKIP_WAL_CHECK` – Skip WAL‑flush wait *(default: false)*  
+- `--influx-only` / `INFLUX_ONLY` – Skip source query; return Influx count only *(default: false)*  
+
+
+## Use Cases
+
+| Intent | Command |
+|--------|---------|
+| Validate **entire** migration of `benchmark3.cpu` | `python validator.py` |
+| Validate migration for a **date partition** | `python validator.py --start-time 2025-01-01T00:00:00Z --end-time 2025-02-01T00:00:00Z` |
+| Validate migration against **Timestream** | `python validator.py --engine timestream` |
+| Validate migration for a **transformed table** | `python validator.py --schema-tags=service_environment,os,arch,service_version,team,region`<br/><br/>If changes were made to the original table schema during the transformation to Line Protocol (ie. using the [`--dimensions-to-fields` flag](link_to_athena_script)), pass the full list of tags from the new table schema to `--schema-tags` as a comma-separated list.|
+| Track an **ongoing migration** | `python validator.py --influx-only --skip-wal-check`<br/><br/>During active ingestion, the validation script allows you to check progress by displaying the current record count in InfluxDB without querying the source engine. This provides visibility into raw data ingestion but excludes any records that may still be undergoing post-ingestion processing.
+
+
+## Output Examples
+
+### Success Output
+```
+Starting validation ... (engine = athena)
+
+--- InfluxDB ---
+Total LP points in bucket.cpu (begin – now): 124761600
+
+--- Athena ---
+Total records in default.cpu_usage_smol (begin – now): 124761600
+
+⏱ Athena query time: 23.31 s
+⏱ InfluxDB query time:   1.01 s
+
+--------- Migration Results ---------
+
+🎉  Athena and InfluxDB row counts match.
+```
+
+### Mismatch Output
+```
+Starting validation ... (engine = athena)
+
+--- InfluxDB ---
+Total LP points in bucket3.cpu (2025-03-01T00:00:00Z – 2025-03-02T00:00:00Z): 10634255
+
+--- Athena ---
+Total records in default.cpu_usage (2025-03-01T00:00:00Z – 2025-03-02T00:00:00Z): 11180160
+
+⏱ Athena query time: 12.88 s
+⏱ InfluxDB query time:   0.68 s
+
+--------- Migration Results ---------
+
+⚠️  Athena (11180160) > InfluxDB (10634255)
+```
+
+## Troubleshooting & Tips
+
+- When ingesting large amounts of data to InfluxDB, [post-ingestion processing and compaction](https://www.influxdata.com/blog/compactor-hidden-engine-database-performance/#:~:text=loading%20and%20reading.-,Tasks%20of%20post%2Dingestion%20and%20pre%2Dquery,delete%20application%2C%20and%20data%20deduplication.) in the InfluxDB [storage engine](https://docs.influxdata.com/influxdb/v2/reference/internals/storage-engine/) can take some time. To skip waiting for the WAL to flush, run with `--skip-wal-check` to retrieve the total count without accounting for post-ingestion processing.
+
+- If data is still being written to InfluxDB at time of validation (ie. simulataneous migrations to the same InfluxDB instance in different buckets or measurements), the WAL will remain non-empty until it has fully processed all ingested points. Ensure that ingestion is fully complete before running comparisons between a target database/table and bucket/measurement, or use the `--skip-wal-check` flag.
+
+- If the total row count exported from Timestream is known at time of validation (ie. unloaded with [DynamoDB logging enabled on export to S3](link_to_balwanth_readme)), avoid querying the source engine using the `--influx-only` flag.
+
+- For large datasets, consider using time range filters to validate in smaller chunks.
+- When validating transformed tables (with converted dimensions as fields), ensure you specify all schema tags for accurate comparison. See output of [the transformation script](trevor_athena_script) for the full list of tags.

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/example.env
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/example.env
@@ -1,0 +1,23 @@
+ENGINE=athena
+
+# Athena configuration
+ATHENA_DB=default
+ATHENA_TABLE=benchmark
+ATHENA_OUTPUT=s3://influx-migration/athena-query-results/
+
+# Timestream configuration
+TIMESTREAM_DB=benchmark
+TIMESTREAM_TABLE=cpu
+
+# InfluxDB configuration
+INFLUX_URL=https://example.com:8086
+INFLUX_TOKEN=your_token_here
+INFLUX_ORG=my-org
+INFLUX_BUCKET=bucket3
+INFLUX_MEASUREMENT=cpu
+
+# Optional parameters
+SCHEMA_TAGS=service_environment,os,arch
+START_TIME=2024-08-01T00:00:00Z
+END_TIME=2024-08-02T00:00:00Z
+POLL_METRICS_INTERVAL=30

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/requirements.txt
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/requirements.txt
@@ -1,0 +1,4 @@
+boto3==1.38.0
+influxdb-client==1.48.0
+python-dotenv==1.1.0
+requests==2.32.3

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
@@ -491,7 +491,7 @@ def main() -> None:
             args.influx_org,
             args.influx_bucket,
             args.influx_measurement,
-            "migration_label",
+            "la_unload",
             args.start_time,
             args.end_time,
         )

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
@@ -1,1 +1,563 @@
-# TODO
+"""
+Compare row/point counts between an Amazon Athena (or Timestream) table and an InfluxDB
+bucket measurement, optionally within a specific time‑range.
+
+Example CLI usage:
+
+    python validate.py \
+        --engine timestream \
+        --timestream-db benchmark3 \
+        --timestream-table cpu \
+        --influx-url https://example.com:8086 \
+        --influx-token MYTOKEN \
+        --influx-org my-org \
+        --influx-bucket bucket3 \
+        --influx-measurement cpu \
+        --schema-tags service_environment,os,arch \
+        --start-time 2024-08-01T00:00:00Z \
+        --end-time 2024-08-02T00:00:00Z
+
+Or simply:
+    # Define variables in .env file (see example.env)
+    python validate.py
+"""
+from __future__ import annotations
+import argparse
+import os
+import sys
+import time
+import datetime as dt
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, List, Sequence, Tuple
+import requests
+
+# Third‑party deps
+from dotenv import load_dotenv
+import boto3
+import influxdb_client
+
+# ───────────────────────── Helpers ──────────────────────────
+
+def timed(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Tuple[Any, float]:
+    """Execute *func* and measure its runtime."""
+    start = time.perf_counter()
+    result = func(*args, **kwargs)
+    return result, time.perf_counter() - start
+
+
+def initialize_session() -> boto3.Session:
+    """Create a fresh `boto3.Session`."""
+    return boto3.Session()
+
+
+def extract_wal_values(payload: str) -> List[float]:
+    """
+    Return a list of non-zero floats found on storage_wal_size lines.
+    Splitting on whitespace is valid per the Prometheus exposition spec.
+    """
+    vals: List[float] = []
+    for line in payload.splitlines():
+        if line.startswith("storage_wal_size"):
+            # "<metric>{labels} <value>"
+            try:
+                value_str = line.split(None, 1)[1]
+                val = float(value_str)
+            except (IndexError, ValueError):
+                continue
+            if val != 0:
+                vals.append(val)
+    return vals
+
+
+def poll_metrics(session, url, timeout=60) -> List[float]:
+    """Fetch /metrics and return non-zero WAL sizes (may be empty)."""
+    r = session.get(f"{url}/metrics", timeout=timeout)
+    r.raise_for_status()
+    return extract_wal_values(r.text)
+
+
+# ───────────────── Timestream utilities ─────────────────────
+
+def count_timestream_rows(
+    session: boto3.Session,
+    database: str,
+    table: str,
+    dimensions: Sequence[str] | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+) -> int | None:
+    """Count rows in an Amazon Timestream table.
+
+    Args:
+        session: Active boto3 session.
+        database: Timestream database name.
+        table: Timestream table name.
+        dimensions: Dimension (tag) columns to use in case of transformed schema. When
+            provided the query counts distinct `(measure_name, *dimensions,
+            time)` tuples; otherwise a plain `COUNT(*)` is executed.
+        start_time: Inclusive lower-bound (ISO-8601).  None = no lower bound.
+        end_time:   Exclusive upper-bound (ISO-8601).  None = no upper bound.
+
+    Returns:
+        Row count, or `None` on failure.
+    """
+    if dimensions is None:
+        dimensions = []
+
+    client = session.client("timestream-query")
+
+    select_expr = (
+        f"COUNT(DISTINCT(measure_name, {', '.join(dimensions)}, time))"
+        if dimensions
+        else "COUNT(*)"
+    )
+    query = f'SELECT {select_expr} AS c FROM "{database}"."{table}"'
+
+    where_clauses: list[str] = []
+    if start_time:
+        where_clauses.append(
+            f"time >= from_iso8601_timestamp('{start_time}')")
+    if end_time:
+        where_clauses.append(
+            f"time <  from_iso8601_timestamp('{end_time}')")
+    if where_clauses:
+        query += " WHERE " + " AND ".join(where_clauses)
+
+    rows: list[dict] = []
+    next_token: str | None = None
+
+    try:
+        while True:
+            params: dict[str, str] = {"QueryString": query}
+            if next_token:
+                params["NextToken"] = next_token
+
+            resp = client.query(**params)
+            rows.extend(resp.get("Rows", []))
+            next_token = resp.get("NextToken")
+            if not next_token:
+                break
+    except Exception as e:
+        print(f"[Timestream] Error: {e}")
+        return None
+
+    if not rows:
+        return 0
+
+    total = int(rows[0]["Data"][0]["ScalarValue"])
+    label = f"{database}.{table} ({start_time or 'begin'} – {end_time or 'now'})"
+    print(f"--- Timestream ---\nTotal records in {label}: {total}\n")
+    return total
+
+
+# ───────────────── Athena utilities ─────────────────────
+
+def count_athena_rows(
+    session: boto3.Session,
+    database: str,
+    table: str,
+    output_location: str,
+    dimensions: List[str] | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    poll_interval: float = 2.0,
+) -> int | None:
+    """Count rows in an Amazon Athena table.
+
+    Args:
+        session: Active boto3 session.
+        database: Athena database name.
+        table: Athena table name.
+        output_location: S3 location where Athena will store query results.
+        dimensions: Dimension (tag) columns to use in case of transformed schema. When
+            provided the query counts distinct `(measure_name, *dimensions,
+            time)` tuples; otherwise a plain `COUNT(*)` is executed.
+        start_time: Inclusive lower-bound (ISO-8601).  None = no lower bound.
+        end_time:   Exclusive upper-bound (ISO-8601).  None = no upper bound.
+        poll_interval: Seconds to wait between status checks.
+
+    Returns:
+        Row count, or None on failure.
+    """
+    if dimensions is None:
+        dimensions = []
+
+    if "time" in dimensions or "measure_name" in dimensions:
+        raise ValueError(
+            "Please exclude `time` and `measure_name` from the SCHEMA_TAGS list."
+        )
+
+    if dimensions:
+        select_expr = (
+            f"COUNT(DISTINCT(measure_name, {', '.join(dimensions)}, time)) AS c"
+        )
+    else:
+        select_expr = "COUNT(*) AS c"
+
+    query = f'SELECT {select_expr} FROM "{database}"."{table}"'
+
+    # ─ Optional date filtering ─
+    where_clauses: list[str] = []
+    if start_time:
+        where_clauses.append(
+            f"time >= from_iso8601_timestamp('{start_time}')"
+        )
+    if end_time:
+        where_clauses.append(
+            f"time <  from_iso8601_timestamp('{end_time}')"
+        )
+    if where_clauses:
+        query += " WHERE " + " AND ".join(where_clauses)
+
+    client = session.client("athena")
+
+    try:
+        execution = client.start_query_execution(
+            QueryString=query,
+            QueryExecutionContext={"Database": database},
+            ResultConfiguration={"OutputLocation": output_location},
+        )
+        qid = execution["QueryExecutionId"]
+
+        # ─ Poll until finished ─
+        while True:
+            state = client.get_query_execution(QueryExecutionId=qid)[
+                "QueryExecution"
+            ]["Status"]["State"]
+            if state in {"SUCCEEDED", "FAILED", "CANCELLED"}:
+                break
+            time.sleep(poll_interval)
+
+        if state != "SUCCEEDED":
+            print(f"[Athena] Query {state}")
+            return None
+
+        rows = client.get_query_results(QueryExecutionId=qid)["ResultSet"]["Rows"]
+        count = int(rows[1]["Data"][0]["VarCharValue"])
+        label = (
+            f"{database}.{table} ({start_time or 'begin'} – {end_time or 'now'})"
+        )
+        print(f"--- Athena ---\nTotal records in {label}: {count}\n")
+        return count
+    except Exception as e:
+        print(f"[Athena] Error: {e}")
+        return None
+
+
+# ────────────────── InfluxDB utilities ──────────────────────
+
+def _build_range_clause(start_time: str | None, end_time: str | None) -> str:
+    """Return the Flux `range()` clause respecting start_time/end_time."""
+    if not start_time and not end_time:
+        return " |> range(start: 0)"
+
+    start_filter = f'time(v: "{start_time}")' if start_time else "0"
+    stop_filter = f'time(v: "{end_time}")' if end_time else "now()"
+    return f" |> range(start: {start_filter}, stop: {stop_filter})"
+
+
+def count_influx_rows(
+    url: str,
+    token: str,
+    org: str,
+    bucket: str,
+    measurement: str,
+    row_identifier: str = "migration_label",
+    start_time: str | None = None,
+    end_time: str | None = None,
+    timeout: int = 30_000,
+) -> int | None:
+    """Count points in an InfluxDB measurement.
+
+    Args:
+        url: Base URL of the InfluxDB instance.
+        token: InfluxDB access token.
+        org: InfluxDB organisation name.
+        bucket: Target bucket.
+        measurement: Measurement to count.
+        row_identifier: Name of a field that appears exactly once per logical
+            row. Using a single field avoids double‑counting where multiple
+            fields exist.
+        start_time: Inclusive lower-bound (ISO-8601).  None = no lower bound.
+        end_time:   Exclusive upper-bound (ISO-8601).  None = no upper bound.
+        timeout: InfluxDB client timeout.
+
+    Returns:
+        Point count, or `None` on failure.
+    """
+    try:
+        with influxdb_client.InfluxDBClient(url=url, token=token, org=org, timeout=timeout) as client:
+            range_clause = _build_range_clause(start_time, end_time)
+            query = (
+                f'from(bucket: "{bucket}")'
+                f"{range_clause}"
+                f' |> filter(fn: (r) => r._measurement == "{measurement}")'
+                f' |> filter(fn: (r) => r._field == "{row_identifier}")'
+                ' |> group() |> count()'
+            )
+            tables = client.query_api().query(org=org, query=query)
+
+        total = sum(int(rec.get_value()) for tbl in tables for rec in tbl.records)
+        label = f"{bucket}.{measurement} ({start_time or 'begin'} – {end_time or 'now'})"
+        print(f"--- InfluxDB ---\nTotal LP points in {label}: {total}\n")
+        return total
+    except Exception as e:
+        print(f"[InfluxDB] Error: {e}")
+        return None
+
+
+# ────────────────────── CLI parsing ─────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    """
+    Precedence order:
+        1. command-line flags
+        2. environment variables
+    """
+    load_dotenv()
+
+    engine_arg = argparse.ArgumentParser(add_help=False)
+    engine_arg.add_argument(
+        "--engine",
+        choices=["timestream", "athena"],
+        default=os.getenv("ENGINE", "athena"),
+        help="Data source engine, 'timestream' or 'athena'. (Defaults to 'athena')",
+    )
+
+    prelim, remaining = engine_arg.parse_known_args()
+
+    env = os.getenv
+    missing = lambda var: env(var) is None
+
+    parser = argparse.ArgumentParser(
+        parents=[engine_arg],
+        description=(
+            "Validate that Timestream/Athena and InfluxDB have identical "
+            "row/point counts, optionally within a time range."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # – Timestream
+    parser.add_argument(
+        "--timestream-db",
+        default=env("TIMESTREAM_DB"),
+        required=prelim.engine == "timestream" and missing("TIMESTREAM_DB"),
+        help="Timestream database name (required if ENGINE=timestream)",
+    )
+    parser.add_argument(
+        "--timestream-table",
+        default=env("TIMESTREAM_TABLE"),
+        required=prelim.engine == "timestream" and missing("TIMESTREAM_TABLE"),
+        help="Timestream table name (required if ENGINE=timestream)",
+    )
+
+    # – Athena
+    parser.add_argument(
+        "--athena-db",
+        default=env("ATHENA_DB"),
+        required=prelim.engine == "athena" and missing("ATHENA_DB"),
+        help="Athena database name (required if ENGINE=athena)",
+    )
+    parser.add_argument(
+        "--athena-table",
+        default=env("ATHENA_TABLE"),
+        required=prelim.engine == "athena" and missing("ATHENA_TABLE"),
+        help="Athena table name (required if ENGINE=athena)",
+    )
+    parser.add_argument(
+        "--athena-output",
+        default=env("ATHENA_OUTPUT"),
+        required=prelim.engine == "athena" and missing("ATHENA_OUTPUT"),
+        help="Athena query results S3 output location (required if ENGINE=athena)",
+    )
+
+    # – InfluxDB
+    parser.add_argument(
+        "--influx-url",
+        default=env("INFLUX_URL"),
+        required=missing("INFLUX_URL"),
+        help="InfluxDB URL (e.g., 'https://example.com:8086')",
+    )
+    parser.add_argument(
+        "--influx-token",
+        default=env("INFLUX_TOKEN"),
+        required=missing("INFLUX_TOKEN"),
+        help="InfluxDB API token",
+    )
+    parser.add_argument(
+        "--influx-org",
+        default=env("INFLUX_ORG"),
+        required=missing("INFLUX_ORG"),
+        help="InfluxDB organization name",
+    )
+    parser.add_argument(
+        "--influx-bucket",
+        default=env("INFLUX_BUCKET"),
+        required=missing("INFLUX_BUCKET"),
+        help="InfluxDB bucket name",
+    )
+    parser.add_argument(
+        "--influx-measurement",
+        default=env("INFLUX_MEASUREMENT"),
+        required=missing("INFLUX_MEASUREMENT"),
+        help="InfluxDB measurement to validate",
+    )
+
+    # – Optional
+    parser.add_argument(
+        "--schema-tags",
+        default=env("SCHEMA_TAGS", ""),
+        help="Comma-separated list of dimension/tag names",
+    )
+    parser.add_argument(
+        "--start-time",
+        default=env("START_TIME"),
+        help="Inclusive lower time bound in ISO-8601 format (e.g., '2024-08-01T00:00:00Z')",
+    )
+    parser.add_argument(
+        "--end-time",
+        default=env("END_TIME"),
+        help="Exclusive upper time bound in ISO-8601 format (e.g., '2024-08-02T00:00:00Z')",
+    )
+    parser.add_argument(
+        "--poll-metrics-interval",
+        default=env("POLL_METRICS_INTERVAL", 30),
+        help="Polling interval (seconds) for post-ingestion validation to /metrics endpoint",
+    )
+    parser.add_argument(
+        "--skip-wal-check",
+        action="store_true",
+        default=env("SKIP_WAL_CHECK", False),
+        help="Skip waiting for the WAL to complete flushing.",
+    )
+    parser.add_argument(
+        "--influx-only",
+        action="store_true",
+        default=env("INFLUX_ONLY", False),
+        help="Skip querying the source engine (Athena/Timestream) and only "
+             "return the InfluxDB row count.",
+    )
+
+    args = parser.parse_args(remaining, namespace=prelim)
+    return args
+
+
+# ────────────────────────── Main ────────────────────────────
+
+def main() -> None:
+    args = parse_args()
+    print("-"*20)
+    print("Starting validation")
+    print("-"*20)
+
+    # First, check WAL across shards to ensure post-ingestion
+    # is complete
+    poll_interval = args.poll_metrics_interval
+    session = requests.Session()
+
+    if not args.skip_wal_check:
+        print(f"\nPolling {args.influx_url}/metrics to wait for WAL to complete flushing ... \n")
+        while True:
+            timestamp = dt.datetime.now().isoformat(sep=" ", timespec="seconds")
+            try:
+                nz_wals = poll_metrics(session=session, url=args.influx_url)
+            except requests.RequestException as exc:
+                print(f"{timestamp}  request failed ({exc}); retrying in {poll_interval}s")
+                time.sleep(poll_interval)
+                continue
+
+            if nz_wals:
+                print(f"{timestamp}  {len(nz_wals):>2} shards with non-zero WAL "
+                      f"(largest={max(nz_wals)/1024:,.1f} KiB)")
+                time.sleep(poll_interval)
+            else:
+                print(f"{timestamp}  WAL empty on all shards — ready for validation.\n")
+                break
+    else:
+        print(f"\nSkipping check for InfluxDB WAL to complete flushing ...\n")
+
+    schema_tags = [t.strip() for t in args.schema_tags.split(",") if t.strip()]
+    boto3_session = initialize_session()
+
+    # Begin validation
+    print(f"Starting validation ...\n")
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        fut_influx = pool.submit(
+            timed,
+            count_influx_rows,
+            args.influx_url,
+            args.influx_token,
+            args.influx_org,
+            args.influx_bucket,
+            args.influx_measurement,
+            "migration_label",
+            args.start_time,
+            args.end_time,
+        )
+
+
+        # Check Influx result first
+        infl_count, infl_elapsed = fut_influx.result()
+        if infl_count == 0:
+            print(f"❗ InfluxDB returned 0 points in {args.influx_bucket}.")
+            sys.exit(1)
+
+        if args.influx_only:
+            print(f"\n⏱ InfluxDB query time: {infl_elapsed:.2f} s")
+            print("\n--------- Influx-Only Results ---------\n")
+            print(f"InfluxDB row count: {infl_count}\n")
+            return 
+
+        if args.engine == "athena":
+            fut_source = pool.submit(
+                timed,
+                count_athena_rows,
+                boto3_session,
+                args.athena_db,
+                args.athena_table,
+                args.athena_output,
+                schema_tags,
+                args.start_time,
+                args.end_time,
+            )
+        else:  # Timestream
+            fut_source = pool.submit(
+                timed,
+                count_timestream_rows,
+                boto3_session,
+                args.timestream_db,
+                args.timestream_table,
+                schema_tags,
+                args.start_time,
+                args.end_time,
+            )
+
+        src_count,  src_elapsed  = fut_source.result()
+
+    # ─ Timings ─
+    src_label = args.engine.title()
+    print(f"⏱ {src_label} query time: {src_elapsed:.2f} s")
+    print(f"⏱ InfluxDB query time:   {infl_elapsed:.2f} s\n")
+
+    # ─ Report ─
+    print("--------- Migration Results ---------\n")
+    if src_count is None:
+        print(f"⚠️  {src_label} query failed.")
+    if infl_count is None:
+        print("⚠️  InfluxDB query failed.")
+
+    if src_count is not None and infl_count is not None:
+        if src_count == infl_count:
+            print(f"🎉  {src_label} and InfluxDB row counts match.\n")
+        else:
+            sign = ">" if src_count > infl_count else "<"
+            print(
+                f"⚠️  {src_label} ({src_count}) {sign} InfluxDB ({infl_count})\n"
+            )
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit("Interrupted by user.")


### PR DESCRIPTION
Compare row/point counts between Amazon Timestream/Athena and InfluxDB to ensure data integrity during migration processes. The script:
- Supports both Athena and Timestream as source engines
- Waits for InfluxDB's Write-Ahead Log (WAL) to flush before comparison
- Executes count-only queries over identical time windows
- Provides clear output indicating match or mismatch
- Supports optional schema/tag filtering for transformed schemas
- Includes Docker support for easy execution

Will fix breaking links in another pass after other PRs have been merged.
