### PR TITLE
Support preserving nanosecond precision for all timestamp multi-measure record types

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
@@ -120,17 +120,37 @@ def get_athena_ddl_type_mapping(timestream_type: str) -> str:
         )
     return athena_type
 
-
 def get_parquet_column_details(s3_uri: str):
     s3, path = fs.FileSystem.from_uri(s3_uri)
     with s3.open_input_file(path) as file:
         parquet_file = pq.ParquetFile(file)
+        schema = parquet_file.schema_arrow
+        all_field_names = {field.name for field in schema}
+
         formatted_columns = []
-        for field in parquet_file.schema_arrow:
+        processed_fields = set()
+
+        for field in schema:
+            field_name = field.name
+            if field_name in processed_fields:
+                continue
+
             column_type = str(field.type).upper()
-            if column_type == "TIMESTAMP[NS]":
-                column_type = "TIMESTAMP"
-            formatted_columns.append(f"`{field.name}` {column_type}")
+            if not column_type == "TIMESTAMP[NS]":
+                formatted_columns.append(f"`{field_name}` {column_type}")
+                processed_fields.add(field_name)
+            else:
+                ns_field_name = f"{field_name}_ns"
+                # Check if corresponding _ns field exists
+                if ns_field_name in all_field_names:
+                    # Use the _ns field instead and mark both as processed
+                    formatted_columns.append(f"`{ns_field_name}` STRING")
+                    processed_fields.add(field_name)
+                    processed_fields.add(ns_field_name)
+                else:
+                    # No _ns field exists, use the original field
+                    formatted_columns.append(f"`{field_name}` TIMESTAMP")
+                    processed_fields.add(field_name)
         return formatted_columns
 
 def create_and_load_athena_table(
@@ -280,7 +300,7 @@ def translate_athena_table_to_line_protocol(
     wait_for_completion: bool = True,
     max_wait_seconds: int = MAX_WAIT_SECONDS,
     add_validation_field: bool = False,
-    add_time_ns: bool = False,
+    use_ns_precision: bool = False,
 ) -> LineProtocolTranslationResult:
     """
     Translates the contents of an Athena table to line protocol and stores the
@@ -503,12 +523,21 @@ def translate_athena_table_to_line_protocol(
                 lp_translation_query += f"""
                 CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}="' || CAST(\"{measure_value_name}\" AS VARCHAR) || '",' ELSE '' END {delimiter}
                 """
+            elif measure_value_type == "timestamp":
+                if use_ns_precision:
+                    lp_translation_query += f"""
+                    CASE WHEN \"{measure_value_name}_ns\" IS NOT NULL THEN '{measure_value_name}=' || {measure_value_name}_ns || ',' ELSE '' END {delimiter}
+                    """
+                else:
+                    lp_translation_query += f"""
+                    CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}=' || CAST(CAST(TO_UNIXTIME({measure_value_name}) * 1000 AS BIGINT) AS VARCHAR) || ',' ELSE '' END {delimiter}
+                    """
             else:
                 lp_translation_query += f"""
                 CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}=' || CAST(\"{measure_value_name}\" AS VARCHAR) || ',' ELSE '' END {delimiter}
                 """
 
-        if add_time_ns:
+        if use_ns_precision:
             # Nanosecond precision, expects time_ns column from unload
             time_query = "time_ns"
         else:
@@ -681,7 +710,6 @@ if __name__ == "__main__":
             if not athena_columns:
                 continue
 
-            # TODO: Update to retrieve schema from parquet
             line_protocol_result = translate_athena_table_to_line_protocol(
                 timestream_utility=timestream_utility,
                 s3_utility=s3_utility,
@@ -695,7 +723,7 @@ if __name__ == "__main__":
                 athena_database_name=args.athena_database_name,
                 athena_table_name=args.athena_table_name,
                 add_validation_field=args.add_validation_field,
-                add_time_ns=("`time_ns` STRING" in athena_columns),
+                use_ns_precision=("`time_ns` STRING" in athena_columns),
             )
             line_protocol_results.append(line_protocol_result)
         except Exception as e:

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
@@ -136,10 +136,8 @@ def get_parquet_column_details(s3_uri: str):
                 continue
 
             column_type = str(field.type).upper()
-            if not column_type == "TIMESTAMP[NS]":
-                formatted_columns.append(f"`{field_name}` {column_type}")
-                processed_fields.add(field_name)
-            else:
+
+            if column_type == "TIMESTAMP[NS]":
                 ns_field_name = f"{field_name}_ns"
                 # Check if corresponding _ns field exists
                 if ns_field_name in all_field_names:
@@ -151,6 +149,12 @@ def get_parquet_column_details(s3_uri: str):
                     # No _ns field exists, use the original field
                     formatted_columns.append(f"`{field_name}` TIMESTAMP")
                     processed_fields.add(field_name)
+            elif column_type == "INT64":
+                formatted_columns.append(f"`{field_name}` BIGINT")
+                processed_fields.add(field_name)
+            else:
+                formatted_columns.append(f"`{field_name}` {column_type}")
+                processed_fields.add(field_name)
         return formatted_columns
 
 def create_and_load_athena_table(
@@ -518,19 +522,22 @@ def translate_athena_table_to_line_protocol(
                 delimiter = "||"
             else:
                 delimiter = ")) ||"
-
             if measure_value_type == "varchar":
                 lp_translation_query += f"""
                 CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}="' || CAST(\"{measure_value_name}\" AS VARCHAR) || '",' ELSE '' END {delimiter}
                 """
+            elif measure_value_type == "bigint":
+                lp_translation_query += f"""
+                CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}=' || CAST(\"{measure_value_name}\" AS VARCHAR) || 'i,' ELSE '' END {delimiter}
+                """
             elif measure_value_type == "timestamp":
                 if use_ns_precision:
                     lp_translation_query += f"""
-                    CASE WHEN \"{measure_value_name}_ns\" IS NOT NULL THEN '{measure_value_name}=' || {measure_value_name}_ns || ',' ELSE '' END {delimiter}
+                    CASE WHEN \"{measure_value_name}_ns\" IS NOT NULL THEN '{measure_value_name}=' || {measure_value_name}_ns || 'i,' ELSE '' END {delimiter}
                     """
                 else:
                     lp_translation_query += f"""
-                    CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}=' || CAST(CAST(TO_UNIXTIME({measure_value_name}) * 1000 AS BIGINT) AS VARCHAR) || ',' ELSE '' END {delimiter}
+                    CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN '{measure_value_name}=' || CAST(CAST(TO_UNIXTIME({measure_value_name}) * 1000 AS BIGINT) AS VARCHAR) || 'i,' ELSE '' END {delimiter}
                     """
             else:
                 lp_translation_query += f"""

--- a/tools/python/liveanalytics_migration_scripts/unload/README.md
+++ b/tools/python/liveanalytics_migration_scripts/unload/README.md
@@ -66,7 +66,7 @@
 <li> If your target is <strong>Timestream for InfluxDB</strong> export in <strong>Parquet format</strong> and <strong>no compression</strong> to meet the ingestion scripts requirements </li>
 <li>Enable DynamoDB logging for tracking and validation</li>
 <li>Configure SNS notifications to receive failure or completion of export</li>
-<li>If your target is <strong>Postgres</strong> choose <strong>CSV</strong>, <strong>GZIP compression</strong>, set <strong>`--add-time-ns` to false</strong>, and <strong>`--max-file-size` to 3GB</strong> to meet the ingestion script requirements. We recommend using AWS Database Migration Service (DMS) with source as S3 (both CSV and Parquet are supported) with PostgreSQL as the target. For scenarios where AWS DMS may not be suitable for your specific requirements, you can use our <a href="../targets/rds_for_postgresql/README.md">PostgreSQL ingestion tool</a> which provides a customizable solution for loading CSV data into PostgreSQL databases.</li>
+<li>If your target is <strong>Postgres</strong> choose <strong>CSV</strong>, <strong>GZIP compression</strong>, set <strong>`--append-timestamps` to false</strong>, and <strong>`--max-file-size` to 3GB</strong> to meet the ingestion script requirements. We recommend using AWS Database Migration Service (DMS) with source as S3 (both CSV and Parquet are supported) with PostgreSQL as the target. For scenarios where AWS DMS may not be suitable for your specific requirements, you can use our <a href="../targets/rds_for_postgresql/README.md">PostgreSQL ingestion tool</a> which provides a customizable solution for loading CSV data into PostgreSQL databases.</li>
 <li>Tool uses <a href="https://docs.aws.amazon.com/timestream/latest/developerguide/export-unload.html" target="_blank" rel="noopener noreferrer" title="Learn more about unload functionality" aria-label="Read about AWS Timestream unload feature">Timestream unload Feature</a>. Unload has limitation on number of partitions, tool will overcome this by running unload in batches if required based and start time and end time provided</li>
 <li>Tool supports partitioning by hour, day, month, or year (default is <strong>day</strong>). To avoid error "The query computation exceeds maximum available memory," make sure each partition under approximately 350GB. For example, if your yearly data in Timestream table exceeds 350GB, consider switching to monthly partitions, and if needed, go even more granular (e.g., daily or hourly) </li>
 <li>  If you choose hourly and still get a “The query computation exceeds maximum available memory” error, you can reduce the number of partitions <strong>(--custom-partition-count)</strong> to a lower number, making sure your exports are successful</li>
@@ -108,8 +108,8 @@
 </div>
 
 <div style="border: 1px solid #ddd; padding: 15px; margin: 10px 0; border-radius: 5px; background-color: #f8f9fa;">
-<h4>Export without `time_ns` column (for Postgres migrations)</h4>
-<pre><code>python3.9 unload.py --export-table --database Demo --table Demo --start-time '2020-03-26 17:24:38' --add-time-ns false</code></pre>
+<h4>Export without appending extra timestamp columns (for Postgres migrations)</h4>
+<pre><code>python3.9 unload.py --export-table --database Demo --table Demo --start-time '2020-03-26 17:24:38' --append-timestamps false</code></pre>
 </div>
 </div>
 
@@ -239,8 +239,8 @@
 <td><code>/data</code></td>
 </tr>
 <tr>
-<td><code>--add-time-ns</code></td>
-<td>Adds `time_ns` column in export to preserve timestamp precision for migrations to InfluxDB<br><i>Default: True</i></td>
+<td><code>--append-timestamps</code></td>
+<td>For InfluxDB migrations. <a href="https://aws.amazon.com/athena">Amazon Athena</a> is used for <a href="../targets/timestream_for_influxdb/transform/README.md">transformations</a> and supports <a href="https://docs.aws.amazon.com/athena/latest/ug/data-types.html#data-types-timestamps">millisecond</a> precision. This flag appends an extra column for each measure of type `timestamp` to preserve nanosecond precision.<br><i>Default: True</i></td>
 <td><code>True</code></td>
 </tr>
 </table>

--- a/tools/python/liveanalytics_migration_scripts/unload/unload.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/unload.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     parser.add_argument("-cp", "--custom-partition-count", help="Custom partition count", default=99, required=False)
     parser.add_argument("-ob", "--order-by-asc", help="data order by time ascending", default=False, type=lambda x: x.lower() in ['true', '1', 'yes'], required=False)
     parser.add_argument("-ld", "--logs-dir", help='Directory for export logs (default: timestream-export-logs)', default = None, required = False)
-    parser.add_argument("-pt", "--append-timestamps", help="Whether to preserve timestamps for nanosecond precision.", default=True, type=lambda x: x.lower() in ['true', '1', 'yes'], required=False)
+    parser.add_argument("-at", "--append-timestamps", help="Whether to append extra timestamp columns for preserving nanosecond precision.", default=True, type=lambda x: x.lower() in ['true', '1', 'yes'], required=False)
 
     #assign arguments to args variable
     args = parser.parse_args()

--- a/tools/python/liveanalytics_migration_scripts/unload/unload.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/unload.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     parser.add_argument("-cp", "--custom-partition-count", help="Custom partition count", default=99, required=False)
     parser.add_argument("-ob", "--order-by-asc", help="data order by time ascending", default=False, type=lambda x: x.lower() in ['true', '1', 'yes'], required=False)
     parser.add_argument("-ld", "--logs-dir", help='Directory for export logs (default: timestream-export-logs)', default = None, required = False)
-    parser.add_argument("-atn", "--add-time-ns", help="Add time_ns column in export to preserve timestamp precision for migrations to InfluxDB", default=True, type=lambda x: x.lower() in ['true', '1', 'yes'], required=False)
+    parser.add_argument("-pt", "--append-timestamps", help="Whether to preserve timestamps for nanosecond precision.", default=True, type=lambda x: x.lower() in ['true', '1', 'yes'], required=False)
 
     #assign arguments to args variable
     args = parser.parse_args()
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     recent_first = args.recent_first
     custom_partition_count = args.custom_partition_count
     order_by_asc = args.order_by_asc 
-    add_time_ns = args.add_time_ns
+    append_timestamps = args.append_timestamps
 
     sts_client = boto3.client("sts")
     region = args.region if args.region else sts_client.meta.region_name
@@ -185,7 +185,7 @@ if __name__ == "__main__":
         'recent_first' : recent_first,
         'custom_partition_count' : custom_partition_count,
         'order_by_asc' : order_by_asc,
-        'add_time_ns': add_time_ns
+        'append_timestamps': append_timestamps
     }
 
     # Create dynamodb logging table if dynamodb logging is enabled

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
@@ -194,11 +194,11 @@ class S3Utility:
         supplied bucket_path prefix.
 
         Args:
-            bucket_path (str): An S3 URI including bucket name and prefix ie.
+            bucket_path (str): An S3 URI including bucket name and prefix i.e.,
                 `s3://my-bucket/benchmark22/cpu/unload-2025-05-23-18:58:58/results`
 
         Returns:
-            str: Full S3 URI to the first file type (ie. parquet) object discovered.
+            str: Full S3 URI to the first file type (i.e., parquet) object discovered.
 
         Raises:
             ValueError: If *bucket_path* does not include both bucket and prefix.

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
@@ -294,7 +294,7 @@ class TimestreamUtility:
         except Exception as err:
             self.logger.error(f"Error publishing message to SNS topic: {str(err)}", exc_info=True)
 
-    def timestream_unload(self, database, table, bucket_s3_uri, partition, export_format, start_time, end_time, compression, migration_tag, max_file_size, kms_key, encryption, escaped_by, field_delimiter, recent_first, custom_partition_count, order_by_asc, preserve_timestamps):
+    def timestream_unload(self, database, table, bucket_s3_uri, partition, export_format, start_time, end_time, compression, migration_tag, max_file_size, kms_key, encryption, escaped_by, field_delimiter, recent_first, custom_partition_count, order_by_asc, append_timestamps):
         """
         Unload data from Timestream to S3
 
@@ -313,7 +313,7 @@ class TimestreamUtility:
             encryption: Encryption type (default: 'SSE_KMS')
             escaped_by: Escaped by character (default: '')
             field_delimiter: Field delimiter (default: ',')
-            preserve_timestamps: Whether timestamps should be preserved
+            append_timestamps: Whether timestamps should be preserved
         """
         self.logger.info(f"Starting unload for {database}.{table}")
         total_rows_exported = 0
@@ -343,7 +343,7 @@ class TimestreamUtility:
             status="unload_started",
         )
         timestamp_measures = []
-        if preserve_timestamps:
+        if append_timestamps:
             timestamp_measures = self.list_timestamp_columns(database, table)
         for index, start_end_pair in enumerate(batches, start=1):
             batch_start_time = start_end_pair[0]  # Gets first timestamp (start time)

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
@@ -403,7 +403,7 @@ class TimestreamUtility:
             encryption: Encryption type (default: 'SSE_KMS')
             escaped_by: Escaped by character (default: '')
             field_delimiter: Field delimiter (default: ', ')
-            timestamp_measures: Comma-separated list of timestamp columns that will be casted as VARCHAR and appended to export.
+            timestamp_measures: Comma-separated list of timestamp columns that will be cast to VARCHAR and appended to export.
 
         Returns:
             str: Timestream unload query

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
@@ -294,7 +294,7 @@ class TimestreamUtility:
         except Exception as err:
             self.logger.error(f"Error publishing message to SNS topic: {str(err)}", exc_info=True)
 
-    def timestream_unload(self, database, table, bucket_s3_uri, partition, export_format, start_time, end_time, compression, migration_tag, max_file_size, kms_key, encryption, escaped_by, field_delimiter, recent_first, custom_partition_count, order_by_asc, add_time_ns):
+    def timestream_unload(self, database, table, bucket_s3_uri, partition, export_format, start_time, end_time, compression, migration_tag, max_file_size, kms_key, encryption, escaped_by, field_delimiter, recent_first, custom_partition_count, order_by_asc, preserve_timestamps):
         """
         Unload data from Timestream to S3
 
@@ -313,6 +313,7 @@ class TimestreamUtility:
             encryption: Encryption type (default: 'SSE_KMS')
             escaped_by: Escaped by character (default: '')
             field_delimiter: Field delimiter (default: ',')
+            preserve_timestamps: Whether timestamps should be preserved
         """
         self.logger.info(f"Starting unload for {database}.{table}")
         total_rows_exported = 0
@@ -341,10 +342,13 @@ class TimestreamUtility:
             time_range=f"start_time >= {start_time} and end_time < {end_time}",
             status="unload_started",
         )
+        timestamp_measures = []
+        if preserve_timestamps:
+            timestamp_measures = self.list_timestamp_columns(database, table)
         for index, start_end_pair in enumerate(batches, start=1):
             batch_start_time = start_end_pair[0]  # Gets first timestamp (start time)
             batch_end_time = start_end_pair[1]    # Gets second timestamp (end time)
-            query = self.build_query(migration_tag, database, table, bucket_s3_uri, partition, export_format, batch_start_time, batch_end_time, compression, max_file_size, kms_key, encryption, escaped_by, field_delimiter, order_by_asc, add_time_ns)
+            query = self.build_query(migration_tag, database, table, bucket_s3_uri, partition, export_format, batch_start_time, batch_end_time, compression, max_file_size, kms_key, encryption, escaped_by, field_delimiter, order_by_asc, timestamp_measures)
             self.log_unload(database=database, table=table, migration_tag=migration_tag, time_range=f'start_time >= {batch_start_time} and end_time < {batch_end_time}', status=f"batch{index}_started")
             rows_exported = self.run_unload_query(query, database, table, batch_start_time, batch_end_time, migration_tag,batch_number=index)
             self.log_unload(database=database, table=table, migration_tag=migration_tag, time_range=f'start_time >= {batch_start_time} and end_time < {batch_end_time}', rows_exported=rows_exported, status=f"batch{index}_completed")
@@ -362,7 +366,25 @@ class TimestreamUtility:
             status="unload_completed",
         )
 
-    def build_query(self, migration_tag, database, table, bucket_s3_uri, partition, export_format, start_time, end_time, compression, max_file_size, kms_key, encryption, escaped_by, field_delimiter, order_by_asc, add_time_ns):
+    def build_query(
+        self,
+        migration_tag,
+        database,
+        table,
+        bucket_s3_uri,
+        partition,
+        export_format,
+        start_time,
+        end_time,
+        compression,
+        max_file_size,
+        kms_key,
+        encryption,
+        escaped_by,
+        field_delimiter,
+        order_by_asc,
+        timestamp_measures,
+    ):
         """
         Build the Timestream unload query with the given parameters
 
@@ -381,6 +403,7 @@ class TimestreamUtility:
             encryption: Encryption type (default: 'SSE_KMS')
             escaped_by: Escaped by character (default: '')
             field_delimiter: Field delimiter (default: ', ')
+            timestamp_measures: Comma-separated list of timestamp columns that will be casted as VARCHAR and appended to export.
 
         Returns:
             str: Timestream unload query
@@ -389,8 +412,9 @@ class TimestreamUtility:
         self.logger.info(f"Building unload query for {database}.{table}")
         unload_query = "UNLOAD("
         unload_query += " SELECT *"
-        if add_time_ns:
-            unload_query += ", CAST(to_nanoseconds(time) AS VARCHAR) as time_ns"
+        if timestamp_measures:
+            for timestamp_measure in timestamp_measures:
+                unload_query += f", CAST(to_nanoseconds({timestamp_measure}) AS VARCHAR) as {timestamp_measure}_ns"
         if partition:
             if partition == "hour":
                 unload_query += ", DATE_FORMAT(time, '%Y-%m-%d %H') as partition_date"
@@ -650,3 +674,29 @@ class TimestreamUtility:
                 raise
         else:
             self.logger.info("DynamoDB logging is disabled. Skipping table creation.")
+
+    def list_timestamp_columns(self, database: str, table: str):
+        """
+        Retrieves all columns of type TIMESTAMP from the specified Timestream table.
+
+        Args:
+            database (str): The name of the Timestream database.
+            table (str): The name of the Timestream table.
+
+        Returns:
+            List[str]: A list of column names with type TIMESTAMP.
+        """
+        query_string = f'DESCRIBE "{database}"."{table}"'
+        try:
+            response = self.timestream_read_client.query(QueryString=query_string)
+            rows = response.get("Rows", [])
+            timestamp_columns = [
+                row["Data"][0]["ScalarValue"]
+                for row in rows
+                if row["Data"][1]["ScalarValue"].upper() == "TIMESTAMP"
+            ]
+            self.logger.info(f"Timestamp columns in {database}.{table}: {timestamp_columns}")
+            return timestamp_columns
+        except Exception as e:
+            self.logger.error(f"Failed to list timestamp columns for {database}.{table}: {str(e)}", exc_info=True)
+            raise


### PR DESCRIPTION
This change introduces a new flag called `--append-timestamps` to the UNLOAD script. This flag appends an extra column for each measure of type `timestamp` to preserve nanosecond precision when migrating to InfluxDB, as `<col_name>_ns`. The transformation script infers from the unloaded parquet which columns to use when translating to LP, selecting only the relevant timestamp columns when constructing the Athena table from the parquet.

Here is an example curl you can use to write a record with an extra nanosecond timestamp column to help with testing:

```
aws timestream-write write-records   --database-name <db>   --table-name <table>   --records '[
    {
      "Dimensions": [
        {"Name": "host", "Value": "host1"}
      ],
      "MeasureName": "metrics",
      "MeasureValueType": "MULTI",
      "MeasureValues": [
        {
          "Name": "start_time",
          "Value": "1748204880000000003",
          "Type": "TIMESTAMP"
        }
      ],
      "Time": "1748204880000000005",
      "TimeUnit": "NANOSECONDS"
    }
  ]'
```