### PR TITLE
Adding validation support for InfluxDB V3

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/README.md
@@ -92,7 +92,7 @@ Ensure you have run the steps in [README.md#Installation](../../README.md#instal
     export INFLUXDB_V2_TOKEN="xxx"
     ```
 
-    2. Set `influxdb_version` in your config to `v3`
+    2. Set `influxdb_version` in your config to `v3`. Note that *buckets* from V2 are called *databases* in V3.
 
 #### Usage
 

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/README.md
@@ -86,13 +86,13 @@ Ensure you have run the steps in [README.md#Installation](../../README.md#instal
 
     InfluxDB V3 supports [backwards compatibility with prior versions (ie. the V2 write API)](https://docs.influxdata.com/influxdb3/enterprise/write-data/compatibility-apis/).
 
-    Define the following environment variables, omitting `INFLUXDB_V2_ORG` (concept of organizations do not apply in V3):
+    1. Define the following environment variables, omitting `INFLUXDB_V2_ORG` (concept of organizations do not apply in V3):
     ```
     export INFLUXDB_V2_URL="https://influxdb_v3_url:8181"
     export INFLUXDB_V2_TOKEN="xxx"
     ```
 
-    - Set `skip_bucket_check` in the config to `True` (concept of buckets do not apply in V3)
+    2. Set `influxdb_version` in your config to `v3`
 
 #### Usage
 

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/example.migration-config.yaml
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/example.migration-config.yaml
@@ -62,7 +62,6 @@ stage:
     precision: ns
     logs_dir: ingestion-logs
     continue_on_error: true
-    skip_bucket_check: false
 
   #######################################################################
   # VALIDATION

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/example.migration-config.yaml
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/example.migration-config.yaml
@@ -55,6 +55,7 @@ stage:
   # INGESTION
   #######################################################################
   ingest:
+    influxdb_version: v2
     lines_per_batch: 5000
     io_multiplier: 5
     retries: 20

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/main.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/main.py
@@ -197,13 +197,13 @@ def main():
     # ---------
     # INGEST configs
     # ---------
+    influxdb_version = config["stage"]["ingest"]["influxdb_version"]
     lines_per_batch = config["stage"]["ingest"]["lines_per_batch"]
     io_multiplier = config["stage"]["ingest"]["io_multiplier"]
     retries = config["stage"]["ingest"]["retries"]
     precision = config["stage"]["ingest"]["precision"]
     ingest_logs_dir = os.path.join(base_logs_dir, config["stage"]["ingest"]["logs_dir"])
     continue_on_error = config["stage"]["ingest"]["continue_on_error"]
-    skip_bucket_check = config["stage"]["ingest"]["skip_bucket_check"]
 
     influx_args = [
         "-w", str(num_threads),
@@ -215,12 +215,15 @@ def main():
     ]
     if continue_on_error:
         influx_args.append("--continue-on-error")
-    if skip_bucket_check:
+
+    skip_bucket_check = False
+    if influxdb_version == "v3":
+        skip_bucket_check = True
         influx_args.append("--skip-bucket-check")
 
-    influxdb_url = os.environ["INFLUXDB_V2_URL"]
-    influxdb_token = os.environ["INFLUXDB_V2_TOKEN"]
-    influxdb_org = os.environ["INFLUXDB_V2_ORG"]
+    influxdb_url = os.environ.get("INFLUXDB_V2_URL")
+    influxdb_token = os.environ.get("INFLUXDB_V2_TOKEN")
+    influxdb_org = os.environ.get("INFLUXDB_V2_ORG")
 
     migration_logger.info(f"InfluxDB URL: {influxdb_url}")
 
@@ -401,31 +404,31 @@ def main():
         except Exception as e:
             migration_logger.error(f"Error during ingestion: {e}")
 
-        # TODO: add v3 support in validation
-        if not skip_bucket_check:
-            migration_logger.info(f"Executing validation(s) for {db_name}")
-            for table in tables:
-                validation_args = validation_common_args + [
-                    "--timestream-database-name",
-                    db_name,
-                    "--timestream-table-name",
-                    table,
-                    "--influxdb-v2-bucket",
-                    db_name,
-                    "--influxdb-v2-measurement",
-                    table,
-                ]
-                if db_name in dimensions_to_fields_map.keys():
-                    dims = timestream_utility.list_dimension_columns(db_name, table)
-                    for table_name, dimensions in dimensions_to_fields_map[db_name].items():
-                        if table_name == table:
-                            schema_tags = [dim for dim in dims if dim not in dimensions]
-                            tags = validator.get_quoted_tags(schema_tags)
-                            validation_args += [
+        migration_logger.info(f"Executing validation(s) for {db_name}")
+        for table in tables:
+            validation_args = validation_common_args + [
+                "--timestream-database-name",
+                db_name,
+                "--timestream-table-name",
+                table,
+                "--influxdb-v2-bucket",
+                db_name,
+                "--influxdb-v2-measurement",
+                table,
+                "--influxdb-version",
+                influxdb_version,
+            ]
+            if db_name in dimensions_to_fields_map.keys():
+                dims = timestream_utility.list_dimension_columns(db_name, table)
+                for table_name, dimensions in dimensions_to_fields_map[db_name].items():
+                    if table_name == table:
+                        schema_tags = [dim for dim in dims if dim not in dimensions]
+                        tags = validator.get_quoted_tags(schema_tags)
+                        validation_args += [
 
-                                "--schema-tags", tags
-                            ]
-                validator.main(validation_args)
+                            "--schema-tags", tags
+                        ]
+            validator.main(validation_args)
 
     migration_logger.info("Validation complete.")
     # ---------

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
@@ -339,8 +339,7 @@ def count_influx_v3_rows(
     end_time: str | None = None
 ) -> int | None:
     """
-    Count points in an InfluxDB v3 table via the InfluxQL /query
-    endpoint.
+    Count points in an InfluxDB v3 table via the InfluxDB v3 HTTP query API.
 
     Args:
         url: Base URL of the InfluxDB V3 instance.
@@ -366,27 +365,36 @@ def count_influx_v3_rows(
     query = f'SELECT COUNT("{row_identifier}") FROM "{measurement}"{time_filter}'
     validation_logger.info(f"--- InfluxDB v3 ---\n\nRunning query:\n{query}\n")
 
+    payload = {
+        "db": database,
+        "q": query,
+        "format": "jsonl"
+    }
+
     try:
-        resp = requests.get(
-            f"{url.rstrip('/')}/query",
+        resp = requests.post(
+            f"{url.rstrip('/')}/api/v3/query_influxql",
             headers=headers,
-            params={"db": database, "q": query}
+            json=payload
         )
         resp.raise_for_status()
-        data = resp.json()
+        # JSONL streams lines; pick first
+        lines = resp.text.strip().splitlines()
+        first = json.loads(lines[0]) if lines else {}
     except Exception as exc:
         raise RuntimeError(f"InfluxDB v3 request failed: {exc}") from exc
 
     try:
-        # JSON format: results[0].series[0].values[0][1] = count
-        result = data["results"][0]
-        series = result["series"][0]
-        total = int(series["values"][0][1])
-    except (KeyError, IndexError, ValueError) as exc:
-        raise RuntimeError(f"Unexpected v3 response shape: {json.dumps(data)}") from exc
+        # InfluxQL returns 'count' field
+        total = int(first.get("count") or next(iter(first.values())))
+    except Exception as exc:
+        validation_logger.error(f"InfluxDB v3 response does not contain count, likely due to non-existent table.")
+        return 0
+
 
     label = f"{database}.{measurement} ({start_time or 'begin'} - {end_time or 'now'})"
     validation_logger.info(f"[INFLUXDB-v3] Total LP points in {label}: {total}\n")
+
     return total
 
 # ────────────────────── CLI parsing ─────────────────────────
@@ -663,9 +671,6 @@ def main(input_args) -> None:
 
     if infl_count is None:
         validation_logger.error("\n❌ InfluxDB query failed - cannot continue comparison.")
-    elif infl_count == 0:
-        validation_logger.info(f"\n❗ InfluxDB returned 0 points in {args.influxdb_v2_bucket}.")
-        return
 
     if infl_count is not None and args.influx_only:
         validation_logger.info(f"\n⏱ InfluxDB query time: {infl_elapsed:.2f}s")
@@ -682,7 +687,7 @@ def main(input_args) -> None:
 
         if src_count is not None and infl_count is not None:
             if src_count == infl_count:
-                validation_logger.info(f"🎉  {src_label} and InfluxDB row counts match.\n")
+                validation_logger.info(f"🎉  {src_label} and InfluxDB row counts match ({src_count}).\n")
             else:
                 sign = ">" if src_count > infl_count else "<"
                 validation_logger.info(f"⚠️  {src_label} ({src_count}) {sign} InfluxDB ({infl_count})\n")

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
@@ -31,8 +31,14 @@ import logging
 import sys
 import time
 import datetime as dt
+import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, List, Sequence, Tuple, Dict
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+)
+
 
 from pandas.io.parsers.readers import csv
 import requests
@@ -323,6 +329,65 @@ def count_influx_rows(
     validation_logger.info(f"[INFLUXDB] Total LP points in {label}: {total}\n")
     return total
 
+def count_influx_v3_rows(
+    url: str,
+    token: str,
+    database: str,
+    measurement: str,
+    row_identifier: str = "migration_label",
+    start_time: str | None = None,
+    end_time: str | None = None
+) -> int | None:
+    """
+    Count points in an InfluxDB v3 table via the InfluxQL /query
+    endpoint.
+
+    Args:
+        url: Base URL of the InfluxDB V3 instance.
+        token: InfluxDB access token.
+        database: Name of the database.
+        measurement: Measurement to query.
+        row_identifier: Field that appears exactly once per logical row.
+        start_time: Inclusive lower-bound (ISO-8601).  None = no lower bound.
+        end_time:   Exclusive upper-bound (ISO-8601).  None = no upper bound.
+
+    Returns:
+        Point count, or `None` on failure.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    # Build the InfluxQL WHERE clause for the optional time filter
+    where_parts: list[str] = []
+    if start_time:
+        where_parts.append(f"time >= '{start_time}'")
+    if end_time:
+        where_parts.append(f"time < '{end_time}'")
+    time_filter = f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
+
+    query = f'SELECT COUNT("{row_identifier}") FROM "{measurement}"{time_filter}'
+    validation_logger.info(f"--- InfluxDB v3 ---\n\nRunning query:\n{query}\n")
+
+    try:
+        resp = requests.get(
+            f"{url.rstrip('/')}/query",
+            headers=headers,
+            params={"db": database, "q": query}
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        raise RuntimeError(f"InfluxDB v3 request failed: {exc}") from exc
+
+    try:
+        # JSON format: results[0].series[0].values[0][1] = count
+        result = data["results"][0]
+        series = result["series"][0]
+        total = int(series["values"][0][1])
+    except (KeyError, IndexError, ValueError) as exc:
+        raise RuntimeError(f"Unexpected v3 response shape: {json.dumps(data)}") from exc
+
+    label = f"{database}.{measurement} ({start_time or 'begin'} - {end_time or 'now'})"
+    validation_logger.info(f"[INFLUXDB-v3] Total LP points in {label}: {total}\n")
+    return total
 
 # ────────────────────── CLI parsing ─────────────────────────
 
@@ -394,6 +459,12 @@ def parse_args(input_args: list[str]) -> argparse.Namespace:
     )
 
     # - InfluxDB
+    parser.add_argument(
+        "--influxdb-version",
+        choices=["v2", "v3"],
+        default=env("INFLUXDB_VERSION", "v2"),
+        help="Version of InfluxDB instance to validate.",
+    )
     parser.add_argument(
         "--influxdb-v2-url",
         default=env("INFLUXDB_V2_URL"),
@@ -530,18 +601,31 @@ def main(input_args) -> None:
     errors: Dict[str, Exception] = {}
 
     with ThreadPoolExecutor(max_workers=2) as pool:
-        futures["InfluxDB"] = pool.submit(
-            timed,
-            count_influx_rows,
-            args.influxdb_v2_url,
-            args.influxdb_v2_token,
-            args.influxdb_v2_org,
-            args.influxdb_v2_bucket,
-            args.influxdb_v2_measurement,
-            "la_unload",
-            args.start_time,
-            args.end_time,
-        )
+        if args.influxdb_version == "v3":
+            futures["InfluxDB"] = pool.submit(
+                timed,
+                count_influx_v3_rows,
+                args.influxdb_v2_url,
+                args.influxdb_v2_token,
+                args.influxdb_v2_bucket,
+                args.influxdb_v2_measurement,
+                "la_unload",
+                args.start_time,
+                args.end_time,
+            )
+        else:
+            futures["InfluxDB"] = pool.submit(
+                timed,
+                count_influx_rows,
+                args.influxdb_v2_url,
+                args.influxdb_v2_token,
+                args.influxdb_v2_org,
+                args.influxdb_v2_bucket,
+                args.influxdb_v2_measurement,
+                "la_unload",
+                args.start_time,
+                args.end_time,
+            )
 
         if not args.influx_only:
             if args.source_engine == "athena":


### PR DESCRIPTION
Adds a new config under ingest, `influxdb_version`, which specifies the instance version, required to distinguish how validation is performed.